### PR TITLE
https://github.com/mockrunner/mockrunner/issues/21

### DIFF
--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockQueue.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockQueue.java
@@ -65,6 +65,9 @@ public class MockQueue extends MockDestination implements Queue
         if(!isConsumed)
         {
             addCurrentMessage(message);
+            synchronized (this){	
+            	this.notify();
+            }
         }
     }
 }

--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockQueueReceiver.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockQueueReceiver.java
@@ -30,8 +30,8 @@ public class MockQueueReceiver extends MockMessageConsumer implements QueueRecei
         getConnection().throwJMSException();
         return queue;
     }
-    
-    public Message receive() throws JMSException
+ 
+    public Message receiveNoWait() throws JMSException
     {
         getConnection().throwJMSException();
         if(isClosed())
@@ -51,5 +51,16 @@ public class MockQueueReceiver extends MockMessageConsumer implements QueueRecei
         if(null == message) return null;
         if(session.isAutoAcknowledge()) message.acknowledge();
         return message;
+    }
+    
+    protected void waitOnMessage(long timeout)
+    {
+    	try {
+    		//todo, notify on topic. 
+    		synchronized(queue) {
+    			queue.wait(timeout);
+    		}
+		} catch (InterruptedException e) {
+		}
     }
 }

--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockTopicSubscriber.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockTopicSubscriber.java
@@ -81,7 +81,7 @@ public class MockTopicSubscriber extends MockMessageConsumer implements TopicSub
         return noLocal;
     }
 
-    public Message receive() throws JMSException
+    public Message receiveNoWait() throws JMSException
     {
         getConnection().throwJMSException();
         if(isClosed())
@@ -101,5 +101,17 @@ public class MockTopicSubscriber extends MockMessageConsumer implements TopicSub
         if(null == message) return null;
         if(session.isAutoAcknowledge()) message.acknowledge();
         return message;
+    }
+    
+    protected void waitOnMessage(long timeout)
+    {
+    	try {
+    		synchronized(topic) {
+        		//TODO: notify on topic, wait on timeout
+    			// this behavior causes a 10 ms poll, as opposed to a wait. 
+    			topic.wait(10);
+    		}
+		} catch (InterruptedException e) {
+		}
     }
 }

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMessageConsumerTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMessageConsumerTest.java
@@ -186,20 +186,20 @@ public class MockMessageConsumerTest
         assertNotNull(consumer.receive());
         assertNotNull(consumer.receiveNoWait());
         assertNotNull(consumer.receive(1000));
-        assertNull(consumer.receive());
+        assertNull(consumer.receiveNoWait());
     }
 
     private void doTestReceiveWithSelector(MockMessageConsumer consumer) throws JMSException
     {
         assertNotNull(consumer.receiveNoWait());
         assertNotNull(consumer.receive(1000));
-        assertNull(consumer.receive());
+        assertNull(consumer.receiveNoWait());
     }
     
     private void doTestReceiveWithSelectorDisabled(MockMessageConsumer consumer) throws JMSException
     {
         assertNotNull(consumer.receive());
-        assertNull(consumer.receive());
+        assertNull(consumer.receiveNoWait());
     }
   
     public static class TestMessageListener implements MessageListener

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockQueueSessionTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockQueueSessionTest.java
@@ -314,7 +314,7 @@ public class MockQueueSessionTest
         receiver1.setMessageListener(listener1);
         QueueSender sender = session.createSender(queue);
         sender.send(new MockTextMessage("Text"));
-        assertNull(receiver1.receive());
+        assertNull(receiver1.receiveNoWait());
         assertEquals(new MockTextMessage("Text"), listener1.getMessage());
         listener1.reset();
         receiver1.close();
@@ -322,7 +322,7 @@ public class MockQueueSessionTest
         assertNull(listener1.getMessage());
         try
         {
-            receiver1.receive();
+            receiver1.receiveNoWait();
             fail();
         }
         catch(JMSException exc)
@@ -364,7 +364,7 @@ public class MockQueueSessionTest
         sender.send(message2);
         assertEquals(1, listener1.getMessageList().size());
         assertSame(message2, listener1.getMessageList().get(0));
-        assertNull(receiver1.receive());
+        assertNull(receiver1.receiveNoWait());
         MockQueueReceiver receiver2 = (MockQueueReceiver)session.createReceiver(queue);
         assertSame(message1, receiver2.receiveNoWait());
         receiver2.setMessageListener(listener1);

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockTopicSessionTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockTopicSessionTest.java
@@ -394,7 +394,7 @@ public class MockTopicSessionTest
         TestMessageListener listener1 = new TestMessageListener();
         subscriber1.setMessageListener(listener1);
         publisher.publish(new MockTextMessage("Text"));
-        assertNull(subscriber1.receive());
+        assertNull(subscriber1.receiveNoWait());
         assertEquals(new MockTextMessage("Text"), listener1.getMessage());
         listener1.reset();
         subscriber1.close();
@@ -449,7 +449,7 @@ public class MockTopicSessionTest
         assertEquals(2, listener1.getMessageList().size());
         assertSame(message1, listener1.getMessageList().get(0));
         assertSame(message2, listener1.getMessageList().get(1));
-        assertNull(subscriber1.receive());
+        assertNull(subscriber1.receiveNoWait());
         MockTopicSubscriber subscriber2 = (MockTopicSubscriber)session.createSubscriber(topic);
         assertSame(message3, subscriber2.receiveNoWait());
         subscriber2.setMessageListener(listener1);


### PR DESCRIPTION
receive, recieve(long) and receiveNoWait all acted as if they were "receiveNoWait" from the jms spec.

* Make receive, recieve(long) and receiveNoWait work as per the JMS specification.
* Fixup unit tests to resolve incorrect assertions.
** "Receive()" should never return null, for instance