### PR TITLE
HttpSession.getCreationTime() should throw an exception if the sessio…

### DIFF
--- a/mockrunner-j2ee_1_3/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
+++ b/mockrunner-j2ee_1_3/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
@@ -83,6 +83,7 @@ public class MockHttpSession implements HttpSession
 
     public synchronized long getCreationTime()
     {
+        if (!isValid) throw new IllegalStateException("session invalid");
         return creationTime;
     }
 

--- a/mockrunner-j2ee_1_4/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
+++ b/mockrunner-j2ee_1_4/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
@@ -83,6 +83,7 @@ public class MockHttpSession implements HttpSession
 
     public synchronized long getCreationTime()
     {
+        if (!isValid) throw new IllegalStateException("session invalid");
         return creationTime;
     }
 

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
@@ -83,6 +83,7 @@ public class MockHttpSession implements HttpSession
 
     public synchronized long getCreationTime()
     {
+        if (!isValid) throw new IllegalStateException("session invalid");
         return creationTime;
     }
 


### PR DESCRIPTION
…n is invalid