### PR TITLE
Performance fixes

### DIFF
--- a/mockrunner-core/src/main/java/com/mockrunner/util/regexp/Jsr51PatternMatcher.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/regexp/Jsr51PatternMatcher.java
@@ -1,0 +1,35 @@
+package com.mockrunner.util.regexp;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class Jsr51PatternMatcher extends PatternMatcher.Base {
+   private final Pattern pattern;
+
+   public Jsr51PatternMatcher(String pattern, boolean caseSensitive) {
+      super(pattern);
+      this.pattern = Pattern.compile(pattern, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+   }
+
+   public String type() {
+      return "JSR-51";
+   }
+
+   public boolean matches(String string) {
+      return pattern.matcher(string).matches();
+   }
+
+   public static class Factory implements PatternMatcher.Factory {
+      private final boolean caseSensitive;
+
+      public Factory(boolean caseSensitive) {
+         this.caseSensitive = caseSensitive;
+      }
+
+      public PatternMatcher create(String pattern) {
+         return new Jsr51PatternMatcher(pattern, caseSensitive);
+      }
+   }
+}

--- a/mockrunner-core/src/main/java/com/mockrunner/util/regexp/PatternMatcher.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/regexp/PatternMatcher.java
@@ -1,0 +1,88 @@
+package com.mockrunner.util.regexp;
+
+/**
+ * Defines contract for matching strings.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public interface PatternMatcher extends Comparable<PatternMatcher> {
+   /**
+    * String representation of the type of expressions matched by this pattern matcher.
+    * Examples are 'Perl5', 'JSR-51' or 'equals'. Used for comparison; see {@link #equals(Object)}.
+    * @return The type of this matcher
+    */
+   String type();
+
+   /**
+    * @return Original pattern used for creation of this instance.
+    */
+   String pattern();
+
+   /**
+    * @param string
+    * @return True if the string matches to this pattern.
+    */
+   boolean matches(String string);
+
+   /**
+    * @return The same value as <code>{@link #pattern()}.hashCode()</code>
+    */
+   int hashCode();
+
+   /**
+    * Two instances are considered equal if these use the same {@link #type()} and {@link #pattern()}.
+    *
+    * @param other
+    * @return
+    */
+   boolean equals(Object other);
+
+
+   interface Factory {
+      PatternMatcher create(String pattern);
+   }
+
+   class Factories {
+      public static Factory from(boolean caseSensitive, boolean exactMatch, boolean useRegularExpressions) {
+         if (exactMatch) {
+            return new SimplePatternMatcher.Factory(caseSensitive, true);
+         } else if (useRegularExpressions) {
+            return new Perl5PatternMatcher.Factory(caseSensitive);
+         } else {
+            return new SimplePatternMatcher.Factory(caseSensitive, exactMatch);
+         }
+      }
+   }
+
+   abstract class Base implements PatternMatcher {
+      protected final String originalPattern;
+
+      public Base(String pattern) {
+         this.originalPattern = pattern;
+      }
+
+      public int compareTo(PatternMatcher o) {
+         return pattern().compareTo(o.pattern());
+      }
+
+      @Override
+      public int hashCode() {
+         return pattern().hashCode();
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+         if (obj == null) return false;
+         if (obj == this) return true;
+         if (obj instanceof PatternMatcher) {
+            PatternMatcher other = (PatternMatcher) obj;
+            return pattern().equals(other.pattern()) && type().equals(other.type());
+         }
+         return false;
+      }
+
+      public String pattern() {
+         return originalPattern;
+      }
+   }
+}

--- a/mockrunner-core/src/main/java/com/mockrunner/util/regexp/Perl5PatternMatcher.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/regexp/Perl5PatternMatcher.java
@@ -1,0 +1,43 @@
+package com.mockrunner.util.regexp;
+
+import org.apache.oro.text.regex.MalformedPatternException;
+import org.apache.oro.text.regex.Pattern;
+import org.apache.oro.text.regex.Perl5Compiler;
+import org.apache.oro.text.regex.Perl5Matcher;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class Perl5PatternMatcher extends PatternMatcher.Base {
+   private final Pattern pattern;
+
+   public Perl5PatternMatcher(String pattern, boolean caseSensitive) {
+      super(pattern);
+      try {
+         this.pattern = new Perl5Compiler().compile(pattern,
+               caseSensitive ? Perl5Compiler.DEFAULT_MASK : Perl5Compiler.CASE_INSENSITIVE_MASK);
+      } catch (MalformedPatternException e) {
+         throw new IllegalArgumentException(e);
+      }
+   }
+
+   public String type() {
+      return "Perl5";
+   }
+
+   public boolean matches(String string) {
+      return (new Perl5Matcher().matches(string, pattern));
+   }
+
+   public static class Factory implements PatternMatcher.Factory {
+      private final boolean caseSensitive;
+
+      public Factory(boolean caseSensitive) {
+         this.caseSensitive = caseSensitive;
+      }
+
+      public PatternMatcher create(String pattern) {
+         return new Perl5PatternMatcher(pattern, caseSensitive);
+      }
+   }
+}

--- a/mockrunner-core/src/main/java/com/mockrunner/util/regexp/SimplePatternMatcher.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/regexp/SimplePatternMatcher.java
@@ -1,0 +1,52 @@
+package com.mockrunner.util.regexp;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SimplePatternMatcher extends PatternMatcher.Base {
+   private final String pattern;
+   private final boolean caseSensitive;
+   private final boolean exactMatch;
+
+   public SimplePatternMatcher(String pattern, boolean caseSensitive, boolean exactMatch) {
+      super(pattern);
+      this.pattern = exactMatch || caseSensitive ? pattern : pattern.toUpperCase();
+      this.caseSensitive = caseSensitive;
+      this.exactMatch = exactMatch;
+   }
+
+   public String type() {
+      return "equals";
+   }
+
+   public boolean matches(String string) {
+      if (exactMatch) {
+         if (caseSensitive) {
+            return pattern.equals(string);
+         } else {
+            return pattern.equalsIgnoreCase(string);
+         }
+      } else {
+         if (!caseSensitive) {
+            string = string.toUpperCase();
+         }
+         return string.indexOf(pattern) >= 0;
+      }
+   }
+
+   public static class Factory implements PatternMatcher.Factory {
+      private final boolean caseSensitive;
+      private final boolean exactMatch;
+
+      public Factory(boolean caseSensitive, boolean exactMatch) {
+         this.caseSensitive = caseSensitive;
+         this.exactMatch = exactMatch;
+      }
+
+      public PatternMatcher create(String pattern) {
+         return new SimplePatternMatcher(pattern, caseSensitive, exactMatch);
+      }
+   }
+}

--- a/mockrunner-core/src/main/java/com/mockrunner/util/regexp/StartsEndsPatternMatcher.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/regexp/StartsEndsPatternMatcher.java
@@ -1,0 +1,103 @@
+package com.mockrunner.util.regexp;
+
+/**
+ * Simplified comparison based on JSR-51 regular expressions, applicable only to
+ * patterns with single .* part.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class StartsEndsPatternMatcher extends PatternMatcher.Base {
+   private final String start;
+   private final String end;
+   private final int minLength;
+
+   public StartsEndsPatternMatcher(String pattern, String start, String end) {
+      super(pattern);
+      this.start = start;
+      this.end = end;
+      this.minLength = (start == null ? 0 : start.length()) + (end == null ? 0 : end.length());
+   }
+
+   public String type() {
+      return "JSR-51";
+   }
+
+   public boolean matches(String string) {
+      if (string.length() < minLength) return false;
+      if (start != null && !string.startsWith(start)) return false;
+      if (end != null && !string.endsWith(end)) return false;
+      return true;
+   }
+
+   public static class Factory implements PatternMatcher.Factory {
+      public PatternMatcher create(final String pattern) {
+         String p = pattern;
+         // these are considered implicitly
+         if (p.startsWith("^")) p = p.substring(1);
+         if (p.endsWith("$")) p = p.substring(0, p.length() - 1);
+         int dotStar = p.indexOf(".*");
+
+         if (dotStar < 0) {
+            String unescaped = unescape(p);
+            if (unescaped == null) {
+               return new Jsr51PatternMatcher(pattern, true);
+            } else {
+               return new StartsEndsPatternMatcher(pattern, unescaped, null);
+            }
+         } else {
+            int secondDotStar = p.indexOf(".*", dotStar + 2);
+            if (secondDotStar < 0) {
+               String unescapedStart = unescape(p.substring(0, dotStar));
+               String unescapedEnd = unescape(p.substring(dotStar + 2));
+               if (unescapedStart != null && unescapedEnd != null) {
+                  return new StartsEndsPatternMatcher(pattern,
+                        unescapedStart.length() == 0 ? null : unescapedStart,
+                        unescapedEnd.length() == 0 ? null : unescapedEnd);
+               }
+            }
+            return new Jsr51PatternMatcher(pattern, true);
+         }
+      }
+
+      private String unescape(String pattern) {
+         StringBuilder sb = new StringBuilder(pattern.length());
+         boolean escaped = false;
+         for (char c : pattern.toCharArray()) {
+            if (isSpecial(c)) {
+               if (escaped) {
+                  sb.append(c);
+                  escaped = false;
+               } else if (c == '\\') {
+                  escaped = true;
+               } else {
+                  // special character not escaped
+                  return null;
+               }
+            } else if (escaped) {
+               // unrecognized escape sequence
+               return null;
+            } else {
+               sb.append(c);
+               escaped = false;
+            }
+         }
+         return sb.toString();
+      }
+
+      private boolean isSpecial(char c) {
+         switch (c) {
+            case '\\':
+            case '?':
+            case '.':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+               return true;
+            default:
+               return false;
+         }
+      }
+   }
+
+}

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/AbstractResultSetHandler.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/AbstractResultSetHandler.java
@@ -29,6 +29,7 @@ import com.mockrunner.util.regexp.PatternMatcher;
  */
 public abstract class AbstractResultSetHandler
 {
+    private ResultSetFactory resultSetFactory = ResultSetFactory.Default.INSTANCE;
     private boolean caseSensitive = false;
     private boolean exactMatch = false;
     private boolean useRegularExpressions = false;
@@ -58,7 +59,7 @@ public abstract class AbstractResultSetHandler
      */
     public MockResultSet createResultSet()
     {
-        return new MockResultSet(String.valueOf(Math.random()));
+        return resultSetFactory.create(String.valueOf(Math.random()));
     }
     
     /**
@@ -68,7 +69,7 @@ public abstract class AbstractResultSetHandler
      */
     public MockResultSet createResultSet(String id)
     {
-        return new MockResultSet(id);
+        return resultSetFactory.create(id);
     }
     
     /**
@@ -92,8 +93,24 @@ public abstract class AbstractResultSetHandler
     {
         return factory.create(id);
     }
-    
+
     /**
+     * @return Current falctory used for {@link #createResultSet()} and {@link #createResultSet(String)}
+     */
+    public ResultSetFactory getResultSetFactory() {
+        return resultSetFactory;
+    }
+
+    /**
+     * Set factory used for {@link #createResultSet()} and {@link #createResultSet(String)}
+      *
+     * @param resultSetFactory
+     */
+    public void setResultSetFactory(ResultSetFactory resultSetFactory) {
+        this.resultSetFactory = resultSetFactory;
+    }
+
+   /**
      * Set if specified SQL strings should be handled case sensitive.
      * Defaults to to <code>false</code>, i.e. <i>INSERT</i> is the same
      * as <i>insert</i>.

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/AbstractResultSetHandler.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/AbstractResultSetHandler.java
@@ -359,12 +359,20 @@ public abstract class AbstractResultSetHandler
     {
         ParameterWrapper<MockResultSet[]> wrapper = getMatchingParameterWrapper(sql, parameters, resultSetsForStatement, exactMatchParameter);
 
-        if(null != wrapper){
-            return wrapper.getWrappedObject();
+        if (null == wrapper) {
+            return null;
         }
-        return null;
+        MockResultSet[] resultSets = wrapper.getWrappedObject();
+        if (resultSets == null) {
+            return null;
+        }
+        MockResultSet[] evaluated = new MockResultSet[resultSets.length];
+        for (int i = 0; i < resultSets.length; ++i) {
+            evaluated[i] = resultSets[i].evaluate(sql, parameters);
+        }
+        return evaluated;
     }
-    
+
     /**
      * Returns the if the specified SQL string returns multiple result sets.
      * Please note that you can modify the match parameters with {@link #setCaseSensitive},
@@ -548,12 +556,11 @@ public abstract class AbstractResultSetHandler
     protected MockResultSet getGeneratedKeys(String sql, MockParameterMap parameters, boolean exactMatchParameter)
     {
         ParameterWrapper<MockResultSet> wrapper = getMatchingParameterWrapper(sql, parameters, generatedKeysForStatement, exactMatchParameter);
-        if(null != wrapper)
-        {
-            return wrapper.getWrappedObject();
+        if (null == wrapper) {
+            return null;
         }
-        return null;
-    }    
+        return wrapper.getWrappedObject().evaluate(sql, parameters);
+    }
     
     /**
      * Returns the global generated keys <code>ResultSet</code>.

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/JDBCTestModule.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/JDBCTestModule.java
@@ -214,7 +214,7 @@ public class JDBCTestModule
     public ParameterSets getExecutedSQLStatementParameterSets(String sql)
     {
         Map<String, ParameterSets> map = getExecutedSQLStatementParameterMap();
-        SQLStatementMatcher<ParameterSets> matcher = new SQLStatementMatcher<ParameterSets>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         List<ParameterSets> list = matcher.getMatchingObjects(map, sql, false);
         if(list != null && list.size() > 0)
         {
@@ -351,7 +351,7 @@ public class JDBCTestModule
     public List<MockPreparedStatement> getPreparedStatements(String sql)
     {
         Map<String, List<MockPreparedStatement>> sqlStatements = mockFactory.getMockConnection().getPreparedStatementResultSetHandler().getPreparedStatementMap();
-        SQLStatementMatcher<MockPreparedStatement> matcher = new SQLStatementMatcher<MockPreparedStatement>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         return matcher.getMatchingObjectsFromCollections(sqlStatements, sql, false); 
     }
     
@@ -410,7 +410,7 @@ public class JDBCTestModule
     public List<MockCallableStatement> getCallableStatements(String sql)
     {
         Map<String, List<MockCallableStatement>> sqlStatements = mockFactory.getMockConnection().getCallableStatementResultSetHandler().getCallableStatementMap();
-        SQLStatementMatcher<MockCallableStatement> matcher = new SQLStatementMatcher<MockCallableStatement>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         return matcher.getMatchingObjectsFromCollections(sqlStatements, sql, false); 
     }
     
@@ -588,7 +588,7 @@ public class JDBCTestModule
      */
     public void verifySQLStatementExecuted(String sql)
     {
-        SQLStatementMatcher<Object> matcher = new SQLStatementMatcher<Object>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         if(!matcher.contains(getExecutedSQLStatements(), sql, false))
         {
             throw new VerifyFailedException("Statement " + sql + " not executed.");
@@ -602,7 +602,7 @@ public class JDBCTestModule
      */
     public void verifySQLStatementNotExecuted(String sql)
     {
-        SQLStatementMatcher<Object> matcher = new SQLStatementMatcher<Object>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         if(matcher.contains(getExecutedSQLStatements(), sql, false))
         {
             throw new VerifyFailedException("Statement " + sql + " was executed.");
@@ -727,7 +727,7 @@ public class JDBCTestModule
     private MockParameterMap verifyAndGetParametersForSQL(String sql, int indexOfParameterSet)
     {
         verifySQLStatementExecuted(sql);
-        SQLStatementMatcher<ParameterSets> matcher = new SQLStatementMatcher<ParameterSets>(caseSensitive, exactMatch, useRegularExpressions);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(caseSensitive, exactMatch, useRegularExpressions);
         List<ParameterSets> matchingParameterList = matcher.getMatchingObjects(getExecutedSQLStatementParameterMap(), sql, false);
         if(null == matchingParameterList || matchingParameterList.isEmpty())
         {

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/ResultSetFactory.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/ResultSetFactory.java
@@ -8,4 +8,21 @@ import com.mockrunner.mock.jdbc.MockResultSet;
 public interface ResultSetFactory
 {
     public MockResultSet create(String id);
+
+    class Default implements ResultSetFactory {
+        public final static ResultSetFactory INSTANCE = new Default(false);
+        protected final boolean columnsCaseSensitive;
+
+        public Default(boolean columnsCaseSensitive) {
+            this.columnsCaseSensitive = columnsCaseSensitive;
+        }
+
+        public MockResultSet create(String id) {
+            MockResultSet resultSet = new MockResultSet(id);
+            if (columnsCaseSensitive) {
+                resultSet.setColumnsCaseSensitive(true);
+            }
+            return resultSet;
+        }
+    }
 }

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/EvaluableResultSet.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/EvaluableResultSet.java
@@ -1,5 +1,7 @@
 package com.mockrunner.mock.jdbc;
 
+import com.mockrunner.jdbc.ResultSetFactory;
+
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -49,5 +51,21 @@ public class EvaluableResultSet extends MockResultSet {
     */
    public interface Evaluable {
       Object evaluate(String sql, MockParameterMap parameters, String columnName, int row);
+   }
+
+   public static class Factory implements ResultSetFactory {
+      protected final boolean columnsCaseSensitive;
+
+      public Factory(boolean columnsCaseSensitive) {
+         this.columnsCaseSensitive = columnsCaseSensitive;
+      }
+
+      public EvaluableResultSet create(String id) {
+         EvaluableResultSet resultSet = new EvaluableResultSet(id);
+         if (columnsCaseSensitive) {
+            resultSet.setColumnsCaseSensitive(true);
+         }
+         return resultSet;
+      }
    }
 }

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/EvaluableResultSet.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/EvaluableResultSet.java
@@ -1,0 +1,53 @@
+package com.mockrunner.mock.jdbc;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class EvaluableResultSet extends MockResultSet {
+
+   public EvaluableResultSet(String id) {
+      super(id);
+   }
+
+   public EvaluableResultSet(String id, String cursorName) {
+      super(id, cursorName);
+   }
+
+   @Override
+   public MockResultSet evaluate(String sql, MockParameterMap parameters) {
+      try {
+         MockResultSet newResultSet = new MockResultSet(getId(), getCursorName());
+         ResultSetMetaData metaData = getMetaData();
+         for (int i = 1; i <= getColumnCount(); ++i) {
+            String columnName = metaData.getColumnName(i);
+            List<Object> values = getColumn(columnName);
+            List<Object> newValues = new ArrayList<Object>(values.size());
+            int row = 0;
+            for (Object value : values) {
+               if (value instanceof Evaluable) {
+                  newValues.add(((Evaluable) value).evaluate(sql, parameters, columnName, row));
+               } else {
+                  newValues.add(value);
+               }
+               ++row;
+            }
+            newResultSet.addColumn(columnName, newValues);
+         }
+         return newResultSet;
+      } catch (SQLException e) {
+         throw new RuntimeException("Never triggered", e);
+      }
+   }
+
+   /**
+    * Implementation of this interface will be stored in the result set.
+    */
+   public interface Evaluable {
+      Object evaluate(String sql, MockParameterMap parameters, String columnName, int row);
+   }
+}

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockPreparedStatement.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockPreparedStatement.java
@@ -165,7 +165,7 @@ public class MockPreparedStatement extends MockStatement implements PreparedStat
     {
         return executeQuery(paramObjects);
     }
-    
+
     protected ResultSet executeQuery(MockParameterMap params) throws SQLException
     {
         SQLException exception = resultSetHandler.getSQLException(sql, params);
@@ -179,21 +179,17 @@ public class MockPreparedStatement extends MockStatement implements PreparedStat
             throw exception;
         }
         resultSetHandler.addParameterMapForExecutedStatement(getSQL(), getParameterMapCopy(params));
-        if(resultSetHandler.hasMultipleResultSets(getSQL(), params))
+        MockResultSet[] results = resultSetHandler.getResultSets(getSQL(), params);
+        if (results != null && results.length != 0)
         {
-            MockResultSet[] results = resultSetHandler.getResultSets(getSQL(), params);
-            if(null != results)
+            resultSetHandler.addExecutedStatement(getSQL());
+            if (results.length > 1)
             {
-                resultSetHandler.addExecutedStatement(getSQL());
                 return cloneAndSetMultipleResultSets(results, params);
             }
-        }
-        else
-        {
-            MockResultSet result = resultSetHandler.getResultSet(getSQL(), params);
-            if(null != result){
-                resultSetHandler.addExecutedStatement(getSQL());
-                return cloneAndSetSingleResultSet(result, params);
+            else
+            {
+                return cloneAndSetSingleResultSet(results[0], params);
             }
         }
         ResultSet superResultSet = super.executeQuery(getSQL());
@@ -247,22 +243,16 @@ public class MockPreparedStatement extends MockStatement implements PreparedStat
             throw exception;
         }
         resultSetHandler.addParameterMapForExecutedStatement(getSQL(), getParameterMapCopy(params));
-        if(resultSetHandler.hasMultipleUpdateCounts(getSQL(), params))
+        Integer[] updateCounts = resultSetHandler.getUpdateCounts(getSQL(), params);
+        if (updateCounts != null && updateCounts.length != 0)
         {
-            Integer[] updateCounts = resultSetHandler.getUpdateCounts(getSQL(), params);
-            if(null != updateCounts)
-            {
-                resultSetHandler.addExecutedStatement(getSQL());
+            resultSetHandler.addExecutedStatement(getSQL());
+            if (updateCounts.length > 1) {
                 return setMultipleUpdateCounts(updateCounts.clone(), params);
             }
-        }
-        else
-        {
-            Integer updateCount = resultSetHandler.getUpdateCount(getSQL(), params);
-            if(null != updateCount)
+            else
             {
-                resultSetHandler.addExecutedStatement(getSQL());
-                return setSingleUpdateCount(updateCount, params);
+                return setSingleUpdateCount(updateCounts[0], params);
             }
         }
         int superUpdateCount = super.executeUpdate(getSQL());

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
@@ -160,6 +160,14 @@ public class MockResultSet implements ResultSet, Cloneable
             throw new NestedApplicationException(exc);
         }
     }
+
+   public MockResultSet shallowCopy() {
+      try {
+         return (MockResultSet) super.clone();
+      } catch (CloneNotSupportedException e) {
+         throw new NestedApplicationException(e);
+      }
+   }
     
     /**
      * Returns the id of this <code>ResultSet</code>. Ids are used

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
@@ -105,6 +105,17 @@ public class MockResultSet implements ResultSet, Cloneable
         copyColumnMap();
         adjustInsertRow();
     }
+
+   /**
+    * This method returns instance with contents evaluated using given SQL query and parameters.
+    * This implementation does not evaluate anything and returns directly this.
+    *
+    * @param parameters
+    * @return this instance
+    */
+    public MockResultSet evaluate(String sql, MockParameterMap parameters) {
+        return this;
+    }
     
     /**
      * Set if column names are case sensitive. Default is

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockResultSet.java
@@ -777,7 +777,6 @@ public class MockResultSet implements ResultSet, Cloneable
     
     public Object getObject(String columnName) throws SQLException
     {
-        checkColumnName(columnName);
         checkRowBounds();
         if(rowDeleted()) throw new SQLException("row was deleted");
         List<Object> column;
@@ -789,6 +788,7 @@ public class MockResultSet implements ResultSet, Cloneable
         {
             column = columnMapCopy.get(columnName);
         }
+        checkColumnNotNull(column, columnName);
         Object value = column.get(cursor);
         wasNull = (null == value);
         return value;
@@ -1676,7 +1676,6 @@ public class MockResultSet implements ResultSet, Cloneable
 
     public void updateObject(String columnName, Object value) throws SQLException
     {
-        checkColumnName(columnName);
         checkResultSetConcurrency();
         if(!isCursorInInsertRow)
         {
@@ -1686,11 +1685,13 @@ public class MockResultSet implements ResultSet, Cloneable
         if(isCursorInInsertRow)
         {
             List<Object> column = insertRow.get(columnName);
+            checkColumnNotNull(column, columnName);
             column.set(0, value);
         }
         else
         {
             List<Object> column = columnMapCopy.get(columnName);
+            checkColumnNotNull(column, columnName);
             column.set(cursor, value);
         }
     }
@@ -2184,9 +2185,9 @@ public class MockResultSet implements ResultSet, Cloneable
         throw new SQLException("No object found for " + iface);
     }
     
-    private void checkColumnName(String columnName) throws SQLException
+    private void checkColumnNotNull(List<Object> column, String columnName) throws SQLException
     {
-        if(!columnMap.containsKey(columnName))
+        if(column == null)
         {
             throw new SQLException("No column " + columnName);
         }

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockStatement.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockStatement.java
@@ -119,15 +119,17 @@ public class MockStatement implements Statement
             throw exception;
         }
         resultSetHandler.addExecutedStatement(sql);
-        if(resultSetHandler.hasMultipleResultSets(sql))
+        MockResultSet[] results = resultSetHandler.getResultSets(sql);
+        if (results != null && results.length != 0)
         {
-            MockResultSet[] results = resultSetHandler.getResultSets(sql);
-            if(null != results) return cloneAndSetMultipleResultSets(results);
-        }
-        else
-        {
-            MockResultSet result = resultSetHandler.getResultSet(sql);
-            if(null != result) return cloneAndSetSingleResultSet(result);
+            if (results.length > 1)
+            {
+                return cloneAndSetMultipleResultSets(results);
+            }
+            else
+            {
+                return cloneAndSetSingleResultSet(results[0]);
+            }
         }
         if(resultSetHandler.hasMultipleGlobalResultSets())
         {
@@ -139,7 +141,7 @@ public class MockStatement implements Statement
         }
         return new MockResultSet(String.valueOf(Math.random()));
     }
-    
+
     private MockResultSet cloneAndSetSingleResultSet(MockResultSet result)
     {
         result = cloneResultSet(result);
@@ -193,20 +195,16 @@ public class MockStatement implements Statement
             throw exception;
         }
         resultSetHandler.addExecutedStatement(sql);
-        if(resultSetHandler.hasMultipleUpdateCounts(sql))
+        Integer[] returnValues = resultSetHandler.getUpdateCounts(sql);
+        if (returnValues != null && returnValues.length != 0)
         {
-            Integer[] returnValues = resultSetHandler.getUpdateCounts(sql);
-            if(null != returnValues)
+            if(returnValues.length > 1)
             {
                 return setMultipleUpdateCounts(returnValues);
             }
-        }
-        else
-        {
-            Integer returnValue = resultSetHandler.getUpdateCount(sql);
-            if(null != returnValue)
+            else
             {
-                return setSingleUpdateCount(returnValue);
+                return setSingleUpdateCount(returnValues[0]);
             }
         }
         if(resultSetHandler.hasMultipleGlobalUpdateCounts())

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockStatement.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockStatement.java
@@ -582,6 +582,10 @@ public class MockStatement implements Statement
 
     protected MockResultSet cloneResultSet(MockResultSet resultSet)
     {
+        if (resultSetConcurrency == ResultSet.CONCUR_READ_ONLY) {
+            // no need to clone
+            return resultSet.shallowCopy();
+        }
         if(null == resultSet) return null;
         MockResultSet clone = (MockResultSet)resultSet.clone();
         clone.setStatement(this);
@@ -596,8 +600,12 @@ public class MockStatement implements Statement
         {
             if(null != resultSets[ii])
             {
-                clonedResultsSets[ii] = (MockResultSet)resultSets[ii].clone();
-                clonedResultsSets[ii].setStatement(this);
+                if (resultSetConcurrency == ResultSet.CONCUR_READ_ONLY) {
+                    clonedResultsSets[ii] = resultSets[ii].shallowCopy();
+                } else {
+                    clonedResultsSets[ii] = (MockResultSet) resultSets[ii].clone();
+                    clonedResultsSets[ii].setStatement(this);
+                }
             }
         }
         return clonedResultsSets;

--- a/mockrunner-jdbc/src/test/java/com/mockrunner/test/jdbc/SQLStatementMatcherTest.java
+++ b/mockrunner-jdbc/src/test/java/com/mockrunner/test/jdbc/SQLStatementMatcherTest.java
@@ -20,7 +20,7 @@ public class SQLStatementMatcherTest extends TestCase
 //		testList.add("TestList1");
 //		testList.add("TestList2");
 //		testList.add("TestList3");
-		SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, false);
+		SQLStatementMatcher matcher = new SQLStatementMatcher(true, false);
 		List<String> resultList = matcher.getMatchingObjects(testMap, "Test", false);
 		assertEquals(2, resultList.size());
 		assertTrue(resultList.contains("TestObject1"));
@@ -32,7 +32,7 @@ public class SQLStatementMatcherTest extends TestCase
 		Map<String, String> testMap = new HashMap<String, String>();
 		testMap.put("Test1", "TestObject1");
 		testMap.put("Test2", "TestObject2");
-		SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, false, true);
+		SQLStatementMatcher matcher = new SQLStatementMatcher(true, false, true);
 		List<String> resultList = matcher.getMatchingObjects(testMap, "Test.*", false);
 		assertEquals(2, resultList.size());
 		assertTrue(resultList.contains("TestObject1"));
@@ -48,26 +48,26 @@ public class SQLStatementMatcherTest extends TestCase
 //        testMap.put("Test2", "TestObject2");
 //        testMap.put("Test3", "TestObject3");
 //        testMap.put("Test", "TestObject");
-        SQLStatementMatcher<String> matcher;
+        SQLStatementMatcher matcher;
         List<String> resultList;
-//        SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, true);
+//        SQLStatementMatcher matcher = new SQLStatementMatcher(true, true);
 //        List<String> resultList = matcher.getMatchingObjectsFromCollections(testMap, "Test", false);
 //        assertTrue(resultList.size() == 1);
 //        assertTrue(resultList.contains("TestObject"));
 //        assertFalse(resultList.contains("TestObject1"));
 //        assertFalse(resultList.contains("TestObject2"));
 //        assertFalse(resultList.contains("TestObject3"));
-//        matcher = new SQLStatementMatcher<String>(true, false);
+//        matcher = new SQLStatementMatcher(true, false);
 //        resultList = matcher.getMatchingObjectsFromCollections(testMap, "Test", false);
 //        assertTrue(resultList.size() == 4);
 //        assertTrue(resultList.contains("TestObject"));
 //        assertTrue(resultList.contains("TestObject1"));
 //        assertTrue(resultList.contains("TestObject2"));
 //        assertTrue(resultList.contains("TestObject3"));
-//        matcher = new SQLStatementMatcher<String>(true, false);
+//        matcher = new SQLStatementMatcher(true, false);
 //        resultList = matcher.getMatchingObjectsFromCollections(testMap, "test", false);
 //        assertTrue(resultList.isEmpty());
-//        matcher = new SQLStatementMatcher<String>(false, false);
+//        matcher = new SQLStatementMatcher(false, false);
 //        resultList = matcher.getMatchingObjectsFromCollections(testMap, "test", false);
 //        assertTrue(resultList.size() == 4);
 //        assertTrue(resultList.contains("TestObject"));
@@ -79,7 +79,7 @@ public class SQLStatementMatcherTest extends TestCase
         testList.add("TestList2");
         testList.add("TestList3");
         testMap.put("Test4", testList);
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         resultList = matcher.getMatchingObjectsFromCollections(testMap, "", false);
         assertTrue(resultList.size() == 3);
 //        assertTrue(resultList.contains("TestObject"));
@@ -89,10 +89,10 @@ public class SQLStatementMatcherTest extends TestCase
         assertTrue(resultList.contains("TestList1"));
         assertTrue(resultList.contains("TestList2"));
         assertTrue(resultList.contains("TestList3"));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         resultList = matcher.getMatchingObjectsFromCollections(testMap, "", true);
         assertTrue(resultList.isEmpty());
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         resultList = matcher.getMatchingObjectsFromCollections(testMap, "TestObjectObject", true);
         assertTrue(resultList.isEmpty());
 //        assertTrue(resultList.contains("TestObject"));
@@ -106,7 +106,7 @@ public class SQLStatementMatcherTest extends TestCase
 		testList.add("TestList2");
 		testList.add("TestList3");
 		testMap.put("Test3", testList);
-		SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, false, true);
+		SQLStatementMatcher matcher = new SQLStatementMatcher(true, false, true);
 		List<String> resultList = matcher.getMatchingObjectsFromCollections(testMap, "[T].*", false);
 		assertEquals(3, resultList.size());
     }
@@ -117,25 +117,25 @@ public class SQLStatementMatcherTest extends TestCase
         list.add("TestString1");
         list.add("TestString2");
         list.add("TestString3");
-        SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(false, false);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(false, false);
         assertTrue(matcher.contains(list, "TESTSTRING", false));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         assertFalse(matcher.contains(list, "TESTSTRING", false));
-        matcher = new SQLStatementMatcher<String>(false, true);
+        matcher = new SQLStatementMatcher(false, true);
         assertFalse(matcher.contains(list, "TESTSTRING", false));
-        matcher = new SQLStatementMatcher<String>(true, true);
+        matcher = new SQLStatementMatcher(true, true);
         assertTrue(matcher.contains(list, "TestString3", false));
-        matcher = new SQLStatementMatcher<String>(true, true);
+        matcher = new SQLStatementMatcher(true, true);
         assertFalse(matcher.contains(list, "TestString4", false));
-        matcher = new SQLStatementMatcher<String>(false, false);
+        matcher = new SQLStatementMatcher(false, false);
         assertFalse(matcher.contains(list, "TestString4", false));
-        matcher = new SQLStatementMatcher<String>(false, false);
+        matcher = new SQLStatementMatcher(false, false);
         assertFalse(matcher.contains(list, "TESTSTRING1XYZ", false));
-        matcher = new SQLStatementMatcher<String>(false, false);
+        matcher = new SQLStatementMatcher(false, false);
         assertTrue(matcher.contains(list, "TESTSTRING1XYZ", true));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         assertFalse(matcher.contains(list, "TEstString3Test", true));
-        matcher = new SQLStatementMatcher<String>(false, false);
+        matcher = new SQLStatementMatcher(false, false);
         assertTrue(matcher.contains(list, "TEstString3Test", true));
     }
     
@@ -145,7 +145,7 @@ public class SQLStatementMatcherTest extends TestCase
         list.add("TestString1");
         list.add("TestString2");
         list.add("TestString3");
-        SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(false, false, true);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(false, false, true);
         assertTrue(matcher.contains(list, "TESTSTRING.", false));
         assertTrue(matcher.contains(list, ".*", false));
         assertFalse(matcher.contains(list, "...", false));
@@ -157,37 +157,37 @@ public class SQLStatementMatcherTest extends TestCase
     
     public void testDoStringsMatch()
     {
-        SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, false);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(true, false);
         assertFalse(matcher.doStringsMatch("X", "x"));
-        matcher = new SQLStatementMatcher<String>(false, true);
+        matcher = new SQLStatementMatcher(false, true);
         assertTrue(matcher.doStringsMatch("X", "x"));
-        matcher = new SQLStatementMatcher<String>(false, false);
+        matcher = new SQLStatementMatcher(false, false);
         assertTrue(matcher.doStringsMatch("Test", "tes"));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         assertFalse(matcher.doStringsMatch("Test", "tes"));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         assertTrue(matcher.doStringsMatch("Test", ""));
-        matcher = new SQLStatementMatcher<String>(true, false);
+        matcher = new SQLStatementMatcher(true, false);
         assertTrue(matcher.doStringsMatch("Test", null));
-        matcher = new SQLStatementMatcher<String>(false, true);
+        matcher = new SQLStatementMatcher(false, true);
         assertFalse(matcher.doStringsMatch("Test", null));
-        matcher = new SQLStatementMatcher<String>(true, true);
+        matcher = new SQLStatementMatcher(true, true);
         assertTrue(matcher.doStringsMatch(null, null));
-        matcher = new SQLStatementMatcher<String>(true, true);
+        matcher = new SQLStatementMatcher(true, true);
         assertTrue(matcher.doStringsMatch("ThisIsATest", "ThisIsATest"));
     }
     
     public void testDoStringsMatchRegEx()
     {
-        SQLStatementMatcher<String> matcher = new SQLStatementMatcher<String>(true, false, true);
+        SQLStatementMatcher matcher = new SQLStatementMatcher(true, false, true);
         assertFalse(matcher.doStringsMatch("X", "x"));
         assertTrue(matcher.doStringsMatch("AbcDef", ".*"));
         assertFalse(matcher.doStringsMatch("AbcDef", "a.*"));
-        matcher = new SQLStatementMatcher<String>(false, false, true);
+        matcher = new SQLStatementMatcher(false, false, true);
         assertTrue(matcher.doStringsMatch("AbcDef", "a.*"));
         assertTrue(matcher.doStringsMatch("myTest", "[nmg]ytest"));
         assertFalse(matcher.doStringsMatch("dyTest", "[nmg]ytest"));
-        matcher = new SQLStatementMatcher<String>(true, true, true);
+        matcher = new SQLStatementMatcher(true, true, true);
         assertFalse(matcher.doStringsMatch("myTest", "[nmg]ytest"));
     }
 }


### PR DESCRIPTION
I've implemented several improvements that improve the performance of certain types of mocked operations. The most notable is caching of compiled regular expressions (although this is not the one that brings best speed-up).
Also including EvaluableResultSet to this PR which allows to mock the result set in a more generic way.
The coding style is somewhat mixed - if there are any guidelines (e.g. about spacing) please direct me.