### PR TITLE
JMS Test Module should create Queues/Topics automatically

### DIFF
--- a/mockrunner-jms/src/main/java/com/mockrunner/jms/JMSTestModule.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/jms/JMSTestModule.java
@@ -4252,7 +4252,7 @@ public class JMSTestModule
     private void checkQueueByName(String queueName)
     {
         DestinationManager destinationManager = getDestinationManager();
-        if(null == destinationManager.getQueue(queueName))
+        if(!destinationManager.existsQueue(queueName))
         {
             throw new VerifyFailedException("Queue with name " + queueName + " is not present.");
         }
@@ -4261,7 +4261,7 @@ public class JMSTestModule
     private void checkTopicByName(String topicName)
     {
         DestinationManager destinationManager = getDestinationManager();
-        if(null == destinationManager.getTopic(topicName))
+        if(!destinationManager.existsTopic(topicName))
         {
             throw new VerifyFailedException("Topic with name " + topicName + " is not present.");
         }

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/JMSTestModuleTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/JMSTestModuleTest.java
@@ -1,13 +1,5 @@
 package com.mockrunner.test.jms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -64,6 +56,8 @@ import com.mockrunner.mock.jms.MockTopicConnection;
 import com.mockrunner.mock.jms.MockTopicPublisher;
 import com.mockrunner.mock.jms.MockTopicSession;
 import com.mockrunner.mock.jms.MockTopicSubscriber;
+
+import static org.junit.Assert.*;
 
 public class JMSTestModuleTest
 {
@@ -279,21 +273,13 @@ public class JMSTestModuleTest
         manager.createQueue("test1");
         manager.createQueue("test2");
         assertNotNull(module.getQueue("test1"));
-        assertNotNull(module.getQueue("test2"));
-        assertNull(module.getQueue("xyz"));
+        MockQueue test2 = module.getQueue("test2");
+        assertNotNull(test2);
         QueueSession session = queueConnection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-        session.createQueue("test2");
+        assertSame(test2, session.createQueue("test2"));
         manager.removeQueue("test2");
-        assertNull(module.getQueue("test2"));
-        try
-        {
-            session.createQueue("test2");
-            fail();
-        }
-        catch (JMSException e)
-        {
-            //should throw exception
-        }
+        assertNotNull(module.getQueue("test2"));
+        assertNotSame(test2, module.getQueue("test2"));
     }
     
     @Test
@@ -302,22 +288,15 @@ public class JMSTestModuleTest
         DestinationManager manager = mockFactory.getDestinationManager();
         manager.createTopic("myTopic1");
         manager.createTopic("myTopic2");
-        assertNotNull(module.getTopic("myTopic1"));
-        assertNotNull(module.getTopic("myTopic2"));
-        assertNull(module.getTopic("xyz"));
+        MockTopic topic1 = module.getTopic("myTopic1");
+        MockTopic topic2 = module.getTopic("myTopic2");
+        assertNotNull(topic1);
+        assertNotNull(topic2);
         TopicSession session = topicConnection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
-        session.createTopic("myTopic1");
+        assertSame(topic1, session.createTopic("myTopic1"));
         manager.removeTopic("myTopic1");
-        assertNull(module.getTopic("myTopic1"));
-        try
-        {
-            session.createTopic("myTopic1");
-            fail();
-        }
-        catch (JMSException e)
-        {
-            //should throw exception
-        }
+        assertNotNull(session.createTopic("myTopic1"));
+        assertNotSame(topic1, session.createTopic("myTopic1"));
     }
     
     @Test
@@ -337,24 +316,6 @@ public class JMSTestModuleTest
         assertSame(queue2, session3.createQueue("queue2"));
         assertSame(queue1, session2.createQueue("queue1"));
         assertSame(queue3, session1.createQueue("queue3"));
-        try
-        {
-            session1.createQueue("queue4");
-            fail();
-        }
-        catch (JMSException e)
-        {
-            //should throw exception
-        }
-        try
-        {
-            session3.createTopic("topic3");
-            fail();
-        }
-        catch (JMSException e)
-        {
-            //should throw exception
-        }
     }
     
     @Test

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockQueueSessionTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockQueueSessionTest.java
@@ -91,16 +91,8 @@ public class MockQueueSessionTest
     @Test
     public void testCreateQueues() throws Exception
     {
-        try
-        {
-            session.createQueue("Queue1");
-            fail();
-        }
-        catch(JMSException exc)
-        {
-            //should throw exception
-        }
         DestinationManager manager = connection.getDestinationManager();
+        assertFalse(manager.existsQueue("Queue1"));
         Queue managerQueue1 = manager.createQueue("Queue1");
         Queue managerQueue2 = manager.getQueue("Queue1");
         Queue queue = session.createQueue("Queue1");
@@ -110,15 +102,7 @@ public class MockQueueSessionTest
         manager.createQueue("Queue2");
         assertNotNull(session.createQueue("Queue2"));
         manager.removeQueue("Queue1");
-        try
-        {
-            session.createQueue("Queue1");
-            fail();
-        }
-        catch(JMSException exc)
-        {
-            //should throw exception
-        }
+        assertFalse(manager.existsQueue("Queue1"));
         session.createTemporaryQueue();
         TemporaryQueue tempQueue = session.createTemporaryQueue();
         session.createTemporaryQueue();

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockTopicSessionTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockTopicSessionTest.java
@@ -81,16 +81,8 @@ public class MockTopicSessionTest
     @Test
     public void testCreateTopics() throws Exception
     {
-        try
-        {
-            session.createTopic("Topic1");
-            fail();
-        }
-        catch(JMSException exc)
-        {
-            //should throw exception
-        }
         DestinationManager manager = connection.getDestinationManager();
+        assertFalse(manager.existsTopic("Topic1"));
         Topic managerTopic1 = manager.createTopic("Topic1");
         Topic topic = session.createTopic("Topic1");
         assertTrue(topic == managerTopic1);
@@ -98,15 +90,7 @@ public class MockTopicSessionTest
         manager.createTopic("Topic2");
         assertTrue(manager.getTopic("Topic2") == session.createTopic("Topic2"));
         manager.removeTopic("Topic2");
-        try
-        {
-            session.createTopic("Topic2");
-            fail();
-        }
-        catch(JMSException exc)
-        {
-            //should throw exception
-        }
+        assertFalse(manager.existsTopic("Topic2"));
         session.createTemporaryTopic();
         TemporaryTopic tempTopic = session.createTemporaryTopic();
         assertNotNull(session.getTemporaryTopic(0));


### PR DESCRIPTION
See #30 

getTopic()/getQueue() should auto-create the topic/queue if it doesn't exist yet.

Takes care of race conditions too, if two threads concurrently write to the same auto-created queue, they're guaranteed to get the same one.

The JMSTestModule.checkQueue/TopicByName should not auto-create IMHO, so that's changed, too.