### PR TITLE
When redirecting, set Status code to 302.

### DIFF
--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
@@ -148,6 +148,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     public void sendRedirect(String location) throws IOException
     {
         setHeader("Location", location);
+        setStatus(SC_FOUND);
         wasRedirectSent = true;
     }
 

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
@@ -149,4 +149,11 @@ public class MockHttpServletResponseTest extends TestCase
         String output = response.getOutputStreamContent();
         assertTrue(output.equals(input));
     }
+
+    public void testRedirect() throws IOException
+    {
+        response.sendRedirect("/some-location");
+        assertEquals("/some-location", response.getHeader("Location"));
+        assertEquals(HttpServletResponse.SC_FOUND, response.getStatusCode());
+    }
 }


### PR DESCRIPTION
The Servlet spec just says `sendRedirect` will set

> the appropriate headers

without specifying which headers are to be set.

The [JavaDoc for `sendRedirect`](http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html#sendRedirect(java.lang.String)) says
> this method sets the status code to SC_FOUND 302 (Found)

This PR makes MockRunner-Servlet behave like the latter.