### PR TITLE
Perform URL-encoding in `encodeRedirectURL` and `encodeRedirectUrl`

### DIFF
--- a/mockrunner-jms/pom.xml
+++ b/mockrunner-jms/pom.xml
@@ -43,9 +43,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<compilerVersion>1.5</compilerVersion>
-					<source>1.5</source>
-					<target>1.5</target>
+					<compilerVersion>1.7</compilerVersion>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockMapMessage.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockMapMessage.java
@@ -31,7 +31,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (boolean) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof Boolean)
         {
@@ -49,7 +49,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (byte) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof Byte)
         {
@@ -67,7 +67,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (short) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if((value instanceof Byte) || (value instanceof Short))
         {
@@ -99,7 +99,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (int) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if((value instanceof Byte) || (value instanceof Short) || (value instanceof Integer))
         {
@@ -117,7 +117,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (long) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if((value instanceof Byte) || (value instanceof Short) || (value instanceof Integer) || (value instanceof Long))
         {
@@ -135,7 +135,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (float) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof Float)
         {
@@ -153,7 +153,7 @@ public class MockMapMessage extends MockMessage implements MapMessage
         Object value = getObject(name);
         if(null == value)
         {
-            return (double) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if((value instanceof Double) || (value instanceof Float))
         {

--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockMessage.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockMessage.java
@@ -203,7 +203,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (boolean) null;
+            return false;
         }
         if(value instanceof String)
         {
@@ -221,7 +221,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (byte) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -239,7 +239,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (short) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -257,7 +257,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (int) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -275,7 +275,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (long) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -293,7 +293,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (float) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -311,7 +311,7 @@ public class MockMessage implements Message, Cloneable, Serializable
         Object value = getObjectProperty(name);
         if(value == null)
         {
-            return (double) null;
+            throw new MessageFormatException(getNullPropertyMessage(name));
         }
         if(value instanceof String)
         {
@@ -437,5 +437,9 @@ public class MockMessage implements Message, Cloneable, Serializable
     protected boolean isInWriteMode()
     {
         return isInWriteMode;
+    }
+
+    protected String getNullPropertyMessage(String name) {
+      return String.format("Property %s was null", name);
     }
 }

--- a/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockStreamMessage.java
+++ b/mockrunner-jms/src/main/java/com/mockrunner/mock/jms/MockStreamMessage.java
@@ -27,7 +27,7 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
         data = new Stack();
         remainingBytesPushed = false;
     }
-    
+
     public boolean readBoolean() throws JMSException
     {
         if(isInWriteMode())
@@ -39,7 +39,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (boolean) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("boolean"));
+        }
         if(value instanceof Boolean)
         {
             return (Boolean) value;
@@ -62,7 +64,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (byte) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("byte"));
+        }
         if(value instanceof Byte)
         {
             return (Byte) value;
@@ -85,7 +89,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (short) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("short"));
+        }
         if((value instanceof Byte) || (value instanceof Short))
         {
             return ((Number)value).shortValue();
@@ -130,7 +136,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (int) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("int"));
+        }
         if((value instanceof Byte) || (value instanceof Short) || (value instanceof Integer))
         {
             return ((Number)value).intValue();
@@ -153,7 +161,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (long) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("long"));
+        }
         if((value instanceof Byte) || (value instanceof Short) || (value instanceof Integer) || (value instanceof Long))
         {
             return ((Number)value).longValue();
@@ -176,7 +186,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (float) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("float"));
+        }
         if(value instanceof Float)
         {
             return (Float) value;
@@ -199,7 +211,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
             throw new MessageEOFException("No more data");
         }
         Object value = readObject();
-        if(null == value) return (double) null;
+        if(null == value) {
+            throw new MessageFormatException(getNullDatumMessage("double"));
+        }
         if((value instanceof Float) || (value instanceof Double))
         {
             return ((Number)value).doubleValue();
@@ -519,5 +533,9 @@ public class MockStreamMessage extends MockMessage implements StreamMessage
     public String toString()
     {
         return this.getClass().getName() + ": " + data.toString();
+    }
+
+    private String getNullDatumMessage(String typename) {
+      return String.format("Cannot convert null to a %s.", typename);
     }
 }

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMapMessageTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMapMessageTest.java
@@ -88,7 +88,7 @@ public class MockMapMessageTest
             message.getInt("null");
             fail();
         }
-        catch(NumberFormatException exc)
+        catch(MessageFormatException exc)
         {
             //should throw exception
         }

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMessageTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockMessageTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 
 import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
 import javax.jms.MessageFormatException;
 import javax.jms.MessageNotWriteableException;
 
@@ -126,8 +127,8 @@ public class MockMessageTest
         assertTrue(nameList.contains("byte1"));
         assertTrue(nameList.contains("boolean1"));
     }
-    
-	@Test
+
+    @Test
     public void testNullPropertyName() throws Exception
     {
         MockMessage message = new MockMessage();
@@ -135,7 +136,7 @@ public class MockMessageTest
         {
             message.setDoubleProperty(null, 123.4);
             fail();
-        } 
+        }
         catch(IllegalArgumentException exc)
         {
             //should throw exception
@@ -144,7 +145,7 @@ public class MockMessageTest
         {
             message.setObjectProperty("", "test");
             fail();
-        } 
+        }
         catch(IllegalArgumentException exc)
         {
             //should throw exception
@@ -153,14 +154,56 @@ public class MockMessageTest
         {
             message.setByteProperty(null, (byte)1);
             fail();
-        } 
+        }
         catch(IllegalArgumentException exc)
         {
             //should throw exception
         }
     }
-    
-	@Test
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullFloatProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getFloatProperty(null);
+    }
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullIntProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getIntProperty(null);
+    }
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullByteProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getByteProperty(null);
+    }
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullShortProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getShortProperty(null);
+    }
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullLongProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getLongProperty(null);
+    }
+
+    @Test(expected=MessageFormatException.class)
+    public void testNullDoubleProperty() throws JMSException {
+        MockMessage m = new MockMessage();
+        m.setObjectProperty("null", null);
+        m.getDoubleProperty(null);
+    }
+
+    @Test
     public void testNullProperties() throws Exception
     {
         MockMessage message = new MockMessage();
@@ -168,56 +211,11 @@ public class MockMessageTest
         assertFalse(message.propertyExists("null"));
         assertNull(message.getObjectProperty("null"));
         assertNull(message.getStringProperty("test"));
-        try
-        {
-            message.getDoubleProperty("null");
-            fail();
-        } 
-        catch(NullPointerException exc)
-        {
-            //should throw exception
-        }
-        try
-        {
-            message.getFloatProperty("null");
-            fail();
-        } 
-        catch(NullPointerException exc)
-        {
-            //should throw exception
-        }
-        try
-        {
-            message.getByteProperty("null");
-            fail();
-        } 
-        catch(NumberFormatException exc)
-        {
-            //should throw exception
-        }
-        try
-        {
-            message.getIntProperty("test");
-            fail();
-        } 
-        catch(NumberFormatException exc)
-        {
-            //should throw exception
-        }
-        try
-        {
-            message.getShortProperty("null");
-            fail();
-        } 
-        catch(NumberFormatException exc)
-        {
-            //should throw exception
-        }
         assertFalse(message.getBooleanProperty("null"));
         assertFalse(message.getBooleanProperty("test"));
     }
-    
-	@Test
+
+    @Test
     public void testReadOnlyProperties() throws Exception
     {
         MockMessage message = new MockMessage();
@@ -229,7 +227,7 @@ public class MockMessageTest
         {
             message.setStringProperty("string", "anothertest");
             fail();
-        } 
+        }
         catch(MessageNotWriteableException exc)
         {
             //should throw exception
@@ -238,7 +236,7 @@ public class MockMessageTest
         {
             message.setDoubleProperty("double", 456);
             fail();
-        } 
+        }
         catch(MessageNotWriteableException exc)
         {
             //should throw exception
@@ -248,7 +246,7 @@ public class MockMessageTest
         {
             message.setBooleanProperty("boolean", true);
             fail();
-        } 
+        }
         catch(MessageNotWriteableException exc)
         {
             //should throw exception
@@ -262,7 +260,7 @@ public class MockMessageTest
         assertTrue(message.getBooleanProperty("boolean"));
         assertTrue(message.propertyExists("boolean"));
     }
-    
+
 	@Test
     public void testSetAndGetCorrelationID() throws Exception
     {
@@ -279,7 +277,7 @@ public class MockMessageTest
         assertEquals("test", message.getJMSCorrelationID());
         assertTrue(Arrays.equals("test".getBytes("ISO-8859-1"), message.getJMSCorrelationIDAsBytes()));
     }
-    
+
 	@Test
     public void testClone() throws Exception
     {

--- a/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockStreamMessageTest.java
+++ b/mockrunner-jms/src/test/java/com/mockrunner/test/jms/MockStreamMessageTest.java
@@ -207,7 +207,7 @@ public class MockStreamMessageTest
             message.readDouble();
             fail();
         }
-        catch(NullPointerException exc)
+        catch(MessageFormatException exc)
         {
             //should throw exception
         }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,7 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.mockrunner.base.NestedApplicationException;
 import com.mockrunner.util.common.CaseAwareMap;
-import org.apache.catalina.util.URLEncoder;
 
 /**
  * Mock implementation of <code>HttpServletResponse</code>.
@@ -37,7 +37,6 @@ public class MockHttpServletResponse implements HttpServletResponse
     private int errorCode;
     private int statusCode;
     private List cookies;
-    private URLEncoder urlEncoder;
 
     public MockHttpServletResponse()
     {
@@ -66,7 +65,6 @@ public class MockHttpServletResponse implements HttpServletResponse
         {
             throw new NestedApplicationException(exc);
         }
-        urlEncoder = new URLEncoder();
     }
 
     public String encodeURL(String url)
@@ -76,12 +74,12 @@ public class MockHttpServletResponse implements HttpServletResponse
 
     public String encodeRedirectUrl(String url)
     {
-        return urlEncoder.encode(url);
+        return URLEncoder.encode(url);
     }
 
     public String encodeRedirectURL(String url)
     {
-        return urlEncoder.encode(url);
+        return URLEncoder.encode(url);
     }
 
     public String encodeUrl(String url)

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.mockrunner.base.NestedApplicationException;
 import com.mockrunner.util.common.CaseAwareMap;
+import org.apache.catalina.util.URLEncoder;
 
 /**
  * Mock implementation of <code>HttpServletResponse</code>.
@@ -36,6 +37,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     private int errorCode;
     private int statusCode;
     private List cookies;
+    private URLEncoder urlEncoder;
 
     public MockHttpServletResponse()
     {
@@ -64,6 +66,7 @@ public class MockHttpServletResponse implements HttpServletResponse
         {
             throw new NestedApplicationException(exc);
         }
+        urlEncoder = new URLEncoder();
     }
 
     public String encodeURL(String url)
@@ -73,12 +76,12 @@ public class MockHttpServletResponse implements HttpServletResponse
 
     public String encodeRedirectUrl(String url)
     {
-        return url;
+        return urlEncoder.encode(url);
     }
 
     public String encodeRedirectURL(String url)
     {
-        return url;
+        return urlEncoder.encode(url);
     }
 
     public String encodeUrl(String url)

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
@@ -159,14 +159,14 @@ public class MockHttpServletResponseTest extends TestCase
 
     public void testEncodeRedirectURL() throws IOException {
         final String encoded1 = response.encodeRedirectURL("page#/some-location?a=b&c=d");
-        assertEquals("page%23%2Fsome%2Dlocation%3Fa%3Db%26c%3Dd", encoded1);
+        assertEquals("page%23%2Fsome-location%3Fa%3Db%26c%3Dd", encoded1);
         final String encoded2 = response.encodeRedirectURL("page");
         assertEquals("page", encoded2);
     }
 
     public void testEncodeRedirectUrl() throws IOException {
         final String encoded = response.encodeRedirectUrl("page#/some-location?a=b&c=d");
-        assertEquals("page%23%2Fsome%2Dlocation%3Fa%3Db%26c%3Dd", encoded);
+        assertEquals("page%23%2Fsome-location%3Fa%3Db%26c%3Dd", encoded);
         final String encoded2 = response.encodeRedirectUrl("page");
         assertEquals("page", encoded2);
     }

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletResponseTest.java
@@ -156,4 +156,18 @@ public class MockHttpServletResponseTest extends TestCase
         assertEquals("/some-location", response.getHeader("Location"));
         assertEquals(HttpServletResponse.SC_FOUND, response.getStatusCode());
     }
+
+    public void testEncodeRedirectURL() throws IOException {
+        final String encoded1 = response.encodeRedirectURL("page#/some-location?a=b&c=d");
+        assertEquals("page%23%2Fsome%2Dlocation%3Fa%3Db%26c%3Dd", encoded1);
+        final String encoded2 = response.encodeRedirectURL("page");
+        assertEquals("page", encoded2);
+    }
+
+    public void testEncodeRedirectUrl() throws IOException {
+        final String encoded = response.encodeRedirectUrl("page#/some-location?a=b&c=d");
+        assertEquals("page%23%2Fsome%2Dlocation%3Fa%3Db%26c%3Dd", encoded);
+        final String encoded2 = response.encodeRedirectUrl("page");
+        assertEquals("page", encoded2);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -230,9 +230,6 @@
                         <excludePackageNames>*.internal*</excludePackageNames>
                         <failOnError>false</failOnError>
                     </configuration>
-                    <reports>
-                        <report>javadoc</report>
-                    </reports>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -240,7 +237,6 @@
                     <configuration>
                         <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
                         <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                    </configuration>
                     <reports>
                         <!-- <report>cim</report> generate the Project Continuous Integration
                         System report. -->
@@ -267,6 +263,7 @@
                         <report>scm</report> <!-- generate the Project Source Code Management report. -->
                         <report>summary</report> <!-- generate the Project information reports summary. -->
                     </reports>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -341,11 +338,6 @@
                             <version>2.4</version>
                         </dependency>
                     </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
When invoking `encodeRedirectURL` or `encodeRedirectUrl`, the supplied param was returned. 

This PR changes that so URL-encoding is being done. It relies upon the Catalina implementation that is already available in the classpath. Alternatively, one could use `URLEncoder` from the Java runtime, but I don't know which one to prefer.