### PR TITLE
Make mockrunner-servlet and its dependencies be OSGi bundles with karaf features to fix #56

### DIFF
--- a/mockrunner-all/pom.xml
+++ b/mockrunner-all/pom.xml
@@ -91,6 +91,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.jboss</groupId>
 			<artifactId>jboss-common-core</artifactId>
 			<version>2.2.11.GA</version>

--- a/mockrunner-core/pom.xml
+++ b/mockrunner-core/pom.xml
@@ -19,6 +19,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		
 		<!-- needed in StreamUtil -->
@@ -55,6 +56,30 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Export-Package>
+							com.mockrunner.base,
+							com.mockrunner.gen,
+							com.mockrunner.gen.jar,
+							com.mockrunner.gen.proc,
+							com.mockrunner.test.consistency,
+							com.mockrunner.test.gen,
+							com.mockrunner.test.util,
+							com.mockrunner.util.common,
+							com.mockrunner.util.regexp,
+							com.mockrunner.util.web
+						</Export-Package>Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.karaf.tooling</groupId>
+				<artifactId>karaf-maven-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<!-- Generate a jar for the source files when deploying -->
 				<groupId>org.apache.maven.plugins</groupId>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -15,6 +15,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.mockrunner</groupId>
 			<artifactId>mockrunner-core</artifactId>
 			<version>2.0.2-SNAPSHOT</version>

--- a/mockrunner-jca/pom.xml
+++ b/mockrunner-jca/pom.xml
@@ -20,6 +20,11 @@
 			<version>2.0.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>jboss</groupId>
 			<artifactId>jboss-j2ee</artifactId>
 			<optional>true</optional>

--- a/mockrunner-jdbc/pom.xml
+++ b/mockrunner-jdbc/pom.xml
@@ -20,6 +20,11 @@
 			<version>2.0.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>1.0.4</version>

--- a/mockrunner-jms/pom.xml
+++ b/mockrunner-jms/pom.xml
@@ -19,6 +19,11 @@
 			<artifactId>mockrunner-core</artifactId>
 			<version>2.0.2-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
 		<!-- needed in StreamUtil -->
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/mockrunner-servlet/pom.xml
+++ b/mockrunner-servlet/pom.xml
@@ -15,9 +15,22 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.mockrunner</groupId>
 			<artifactId>mockrunner-core</artifactId>
 			<version>2.0.2-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.mockrunner</groupId>
+			<artifactId>mockrunner-core</artifactId>
+			<version>2.0.2-SNAPSHOT</version>
+			<type>xml</type>
+			<classifier>features</classifier>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
@@ -35,6 +48,24 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Export-Package>
+							com.mockrunner.base,
+							com.mockrunner.example.servlet,
+							com.mockrunner.mock.web,
+							com.mockrunner.servlet
+						</Export-Package>Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.karaf.tooling</groupId>
+				<artifactId>karaf-maven-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<!-- Generate a jar for the source files when deploying -->
 				<groupId>org.apache.maven.plugins</groupId>

--- a/mockrunner-struts/pom.xml
+++ b/mockrunner-struts/pom.xml
@@ -16,8 +16,19 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.mockrunner</groupId>
+			<artifactId>mockrunner-core</artifactId>
+			<version>2.0.2-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.mockrunner</groupId>
 			<artifactId>mockrunner-servlet</artifactId>
 			<version>2.0.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.struts</groupId>

--- a/mockrunner-tag/pom.xml
+++ b/mockrunner-tag/pom.xml
@@ -16,6 +16,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.mockrunner</groupId>
+			<artifactId>mockrunner-core</artifactId>
+			<version>2.0.2-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.mockrunner</groupId>
 			<artifactId>mockrunner-servlet</artifactId>
 			<version>2.0.2-SNAPSHOT</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,52 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.5.1</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                         <supportedProjectTypes>
+                             <supportedProjectType>jar</supportedProjectType>
+                             <supportedProjectType>bundle</supportedProjectType>
+                             <supportedProjectType>war</supportedProjectType>
+                         </supportedProjectTypes>
+                         <instructions>
+                             <Import-Package>*;resolution:=optional</Import-Package>
+                             <Export-Package>com.mockrunner*</Export-Package>
+                         </instructions>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>bundle</id>
+                            <goals>
+                                <goal>bundle</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>4.1.7</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <startLevel>80</startLevel>
+                        <includeTransitiveDependency>false</includeTransitiveDependency>
+                        <aggregateFeatures>false</aggregateFeatures>
+                        <includeProjectArtifact>true</includeProjectArtifact>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>generate-features-file</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>features-generate-descriptor</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>


### PR DESCRIPTION
This PR to fix issue #56 

These changes shouldn't have any effect for non-OSGi applications.  What these changes are, are adding some OSGi-specific headers to some MANIFEST.MF files of some of the jars in mockrunner (only the ones affecting MockHttpServletRequest and MockHttpServletResponse), and attaching an "-features.xml" artifact to the jars.  The latter are "[features repositories](https://karaf.apache.org/manual/latest/provisioning#_features_repositories)" that is used by [apache karaf](https://karaf.apache.org) to load run-time dependencies.

These changes has made it possible for me to use MockHttpServletRequest and MockHttpServlet in a [Pax Exam](https://ops4j1.jira.com/wiki/spaces/PAXEXAM4/overview) integration test for a[ web whiteboard servlet OSGi service.](http://ops4j.github.io/pax/web/SNAPSHOT/User-Guide.html#whiteboard-extender).

_Note_: to make the pax exam test start properly it was necessary to make an <exclusion> of the nekohtml dependency.  Ie. the maven dependencies in the pax exam maven project had to look like this:
``` xml
        <dependency>
            <groupId>com.mockrunner</groupId>
            <artifactId>mockrunner-core</artifactId>
            <version>2.0.2-SNAPSHOT</version>
            <scope>provided</scope>
            <exclusions>
                <exclusion>
                    <groupId>com.atlassian.bundles</groupId>
                    <artifactId>nekohtml</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
        <dependency>
            <groupId>com.mockrunner</groupId>
            <artifactId>mockrunner-servlet</artifactId>
            <version>2.0.2-SNAPSHOT</version>
            <scope>provided</scope>
            <exclusions>
                <exclusion>
                    <groupId>com.atlassian.bundles</groupId>
                    <artifactId>nekohtml</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
        <dependency>
            <groupId>com.mockrunner</groupId>
            <artifactId>mockrunner-servlet</artifactId>
            <version>2.0.2-SNAPSHOT</version>
            <type>xml</type>
            <classifier>features</classifier>
        </dependency>
```

I tried replacing the nekohml dependency with an OSGi bundle of nekohtml 1.9.12 (released in april 2009) made by atlassian.  However the replacement didn't help: the OSGi version of nekohtml still gave pax exam startup problems.

Since I didn't need nekohtml and I just want to have MockHttpServletRequest and MockHttpServletResponse available for my integration test, I haven't investigated the nekohtml issue any further, and I'm submitting this pull request as is.
