### PR TITLE
Give mockhttpservletrequest fluent interface

### DIFF
--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -71,7 +71,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     private boolean sessionCreated;
     private List attributeListener;
     private boolean isAsyncSupported;
-    
+
     public MockHttpServletRequest()
     {
         resetAll();
@@ -112,7 +112,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         attributeListener.add(listener);
     }
-    
+
     public String getParameter(String key)
     {
         String[] values = getParameterValues(key);
@@ -122,7 +122,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
         return null;
     }
-    
+
     /**
      * Clears the parameters.
      */
@@ -166,7 +166,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return Collections.unmodifiableMap(parameters);
     }
-    
+
     public void clearAttributes()
     {
         attributes.clear();
@@ -206,12 +206,12 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
         handleAttributeListenerCalls(key, value, oldValue);
     }
-    
+
     public HttpSession getSession()
     {
         return getSession(true);
     }
-    
+
     public HttpSession getSession(boolean create)
     {
         if(!create && !sessionCreated) return null;
@@ -233,9 +233,9 @@ public class MockHttpServletRequest implements HttpServletRequest
      * Sets the <code>HttpSession</code>.
      * @param session the <code>HttpSession</code>
      */
-    public void setSession(HttpSession session) 
+    public void setSession(HttpSession session)
     {
-        this.session = session;   
+        this.session = session;
     }
 
     public RequestDispatcher getRequestDispatcher(String path)
@@ -248,7 +248,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
         return dispatcher;
     }
-    
+
     /**
      * Returns the map of <code>RequestDispatcher</code> objects. The specified path
      * maps to the corresponding <code>RequestDispatcher</code> object.
@@ -258,15 +258,15 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return Collections.unmodifiableMap(requestDispatchers);
     }
-    
+
     /**
-     * Clears the map of <code>RequestDispatcher</code> objects. 
+     * Clears the map of <code>RequestDispatcher</code> objects.
      */
     public void clearRequestDispatcherMap()
     {
         requestDispatchers.clear();
     }
-    
+
     /**
      * Sets a <code>RequestDispatcher</code> that will be returned when calling
      * {@link #getRequestDispatcher} with the specified path. If no <code>RequestDispatcher</code>
@@ -283,7 +283,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
         requestDispatchers.put(path, dispatcher);
     }
-    
+
     public Locale getLocale()
     {
         if(locales.size() < 1) return Locale.getDefault();
@@ -294,17 +294,17 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return locales.elements();
     }
-    
+
     public void addLocale(Locale locale)
     {
         locales.add(locale);
     }
-    
+
     public void addLocales(List localeList)
     {
         locales.addAll(localeList);
     }
-    
+
     public String getMethod()
     {
         return method;
@@ -314,12 +314,12 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         this.method = method;
     }
-    
+
     public String getAuthType()
     {
         return authType;
     }
-    
+
     public void setAuthType(String authType)
     {
         this.authType = authType;
@@ -365,7 +365,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         if(null == header) return -1;
         return new Integer(header);
     }
-    
+
     public void addHeader(String key, String value)
     {
         List valueList = (List) headers.get(key);
@@ -376,99 +376,99 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
         valueList.add(value);
     }
-    
+
     public void setHeader(String key, String value)
     {
         List valueList = new ArrayList();
         headers.put(key, valueList);
         valueList.add(value);
     }
-    
+
     public void clearHeaders()
     {
         headers.clear();
     }
-    
+
     public String getContextPath()
     {
         return contextPath;
     }
-    
+
     public void setContextPath(String contextPath)
     {
         this.contextPath = contextPath;
     }
-    
+
     public String getPathInfo()
     {
         return pathInfo;
     }
-    
+
     public void setPathInfo(String pathInfo)
     {
         this.pathInfo = pathInfo;
     }
-    
+
     public String getPathTranslated()
     {
         return pathTranslated;
     }
-    
+
     public void setPathTranslated(String pathTranslated)
     {
         this.pathTranslated = pathTranslated;
     }
-    
+
     public String getQueryString()
     {
         return queryString;
     }
-    
+
     public void setQueryString(String queryString)
     {
         this.queryString = queryString;
     }
-    
+
     public String getRequestURI()
     {
         return requestUri;
     }
-    
+
     public void setRequestURI(String requestUri)
     {
         this.requestUri = requestUri;
     }
-    
+
     public StringBuffer getRequestURL()
     {
         return requestUrl;
     }
-    
+
     public void setRequestURL(String requestUrl)
     {
         this.requestUrl = new StringBuffer(requestUrl);
     }
-    
+
     public String getServletPath()
     {
         return servletPath;
     }
-    
+
     public void setServletPath(String servletPath)
     {
         this.servletPath = servletPath;
     }
-    
+
     public Principal getUserPrincipal()
     {
         return principal;
     }
-    
+
     public void setUserPrincipal(Principal principal)
     {
         this.principal = principal;
     }
-    
+
     public String getRemoteUser()
     {
         return remoteUser;
@@ -484,7 +484,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         if(null == cookies) return null;
         return (Cookie[])cookies.toArray(new Cookie[cookies.size()]);
     }
-    
+
     public void addCookie(Cookie cookie)
     {
         if(null == cookies)
@@ -515,7 +515,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return !requestedSessionIdIsFromCookie;
     }
-    
+
     public void setRequestedSessionIdFromCookie(boolean requestedSessionIdIsFromCookie)
     {
         this.requestedSessionIdIsFromCookie = requestedSessionIdIsFromCookie;
@@ -532,7 +532,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         if(!roles.containsKey(role)) return false;
         return (Boolean) roles.get(role);
     }
-    
+
     public void setUserInRole(String role, boolean isInRole)
     {
         roles.put(role, isInRole);
@@ -542,7 +542,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return characterEncoding;
     }
-    
+
     public void setCharacterEncoding(String characterEncoding) throws UnsupportedEncodingException
     {
         this.characterEncoding = characterEncoding;
@@ -552,7 +552,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return contentLength;
     }
-    
+
     public void setContentLength(int contentLength)
     {
         this.contentLength = contentLength;
@@ -562,7 +562,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return contentType;
     }
-    
+
     public void setContentType(String contentType)
     {
         this.contentType = contentType;
@@ -572,57 +572,57 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return protocol;
     }
-    
+
     public void setProtocol(String protocol)
     {
         this.protocol = protocol;
     }
-    
+
     public String getServerName()
     {
         return serverName;
     }
-    
+
     public void setServerName(String serverName)
     {
         this.serverName = serverName;
     }
-    
+
     public int getServerPort()
     {
         return serverPort;
     }
-    
+
     public void setServerPort(int serverPort)
     {
         this.serverPort = serverPort;
     }
-    
+
     public String getScheme()
     {
         return scheme;
     }
-    
+
     public void setScheme(String scheme)
     {
         this.scheme = scheme;
     }
-    
+
     public String getRemoteAddr()
     {
         return remoteAddr;
     }
-    
+
     public void setRemoteAddr(String remoteAddr)
     {
         this.remoteAddr = remoteAddr;
     }
-    
+
     public String getRemoteHost()
     {
         return remoteHost;
     }
-    
+
     public void setRemoteHost(String remoteHost)
     {
         this.remoteHost = remoteHost;
@@ -632,28 +632,28 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return new BufferedReader(new InputStreamReader(bodyContent));
     }
-    
+
     public ServletInputStream getInputStream() throws IOException
     {
         return bodyContent;
     }
-    
+
     public void setBodyContent(byte[] data)
     {
-        bodyContent = new MockServletInputStream(data); 
+        bodyContent = new MockServletInputStream(data);
     }
-    
+
     public void setBodyContent(String bodyContent)
     {
         String encoding = (null == characterEncoding) ? "ISO-8859-1" : characterEncoding;
         try
         {
             setBodyContent(bodyContent.getBytes(encoding));
-        } 
+        }
         catch(UnsupportedEncodingException exc)
         {
             throw new NestedApplicationException(exc);
-        }        
+        }
     }
 
     public String getRealPath(String path)
@@ -661,20 +661,20 @@ public class MockHttpServletRequest implements HttpServletRequest
         HttpSession session = getSession();
         if(null == session) return null;
         return session.getServletContext().getRealPath(path);
-    } 
-    
+    }
+
     public boolean isSecure()
     {
         String scheme = getScheme();
         if(null == scheme) return false;
         return scheme.equals("https");
     }
-    
+
     public String getLocalAddr()
     {
         return localAddr;
     }
-    
+
     public void setLocalAddr(String localAddr)
     {
         this.localAddr = localAddr;
@@ -684,7 +684,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return localName;
     }
-    
+
     public void setLocalName(String localName)
     {
         this.localName = localName;
@@ -694,7 +694,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         return localPort;
     }
-    
+
     public void setLocalPort(int localPort)
     {
         this.localPort = localPort;
@@ -709,7 +709,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         this.remotePort = remotePort;
     }
-    
+
     public boolean isAsyncSupported()
     {
         return isAsyncSupported;
@@ -739,24 +739,24 @@ public class MockHttpServletRequest implements HttpServletRequest
             {
                 callAttributeListenersAddedMethod(key, value);
             }
-    
+
         }
     }
-    
+
     private void callAttributeListenersAddedMethod(String key, Object value)
     {
         for (Object anAttributeListener : attributeListener) {
             ServletRequestAttributeEvent event = new ServletRequestAttributeEvent(getServletContext(), this, key,
-                    value);
+                                                                                  value);
             ((ServletRequestAttributeListener) anAttributeListener).attributeAdded(event);
         }
     }
-    
+
     private void callAttributeListenersReplacedMethod(String key, Object value)
     {
         for (Object anAttributeListener : attributeListener) {
             ServletRequestAttributeEvent event = new ServletRequestAttributeEvent(getServletContext(), this, key,
-                    value);
+                                                                                  value);
             ((ServletRequestAttributeListener) anAttributeListener).attributeReplaced(event);
         }
     }
@@ -765,11 +765,11 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         for (Object anAttributeListener : attributeListener) {
             ServletRequestAttributeEvent event = new ServletRequestAttributeEvent(getServletContext(), this, key,
-                    value);
+                                                                                  value);
             ((ServletRequestAttributeListener) anAttributeListener).attributeRemoved(event);
         }
     }
-    
+
     private ServletContext getServletContext()
     {
         if(null == session) return new MockServletContext();

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
@@ -24,17 +24,17 @@ import com.mockrunner.mock.web.MockRequestDispatcher;
 public class MockHttpServletRequestTest extends TestCase
 {
     private MockHttpServletRequest request;
-    
+
     protected void setUp()
     {
         request = new MockHttpServletRequest();
     }
-    
+
     protected void tearDown()
     {
         request = null;
     }
-    
+
     public void testResetAll() throws Exception
     {
         request.setAttribute("key", "value");
@@ -45,7 +45,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertNull(request.getHeader("header"));
         assertEquals(-1, request.getContentLength());
     }
-    
+
     public void testAttributeListenerCalled()
     {
         TestAttributeListener listener1 = new TestAttributeListener();
@@ -110,7 +110,7 @@ public class MockHttpServletRequestTest extends TestCase
         request.removeAttribute("myKey");
         assertFalse(listener.wasAttributeRemovedCalled());
     }
-    
+
     public void testGetAttributeNames()
     {
         Enumeration enumeration = request.getAttributeNames();
@@ -141,7 +141,7 @@ public class MockHttpServletRequestTest extends TestCase
         enumeration = request.getAttributeNames();
         assertFalse(enumeration.hasMoreElements());
     }
-    
+
     public void testAddRequestParameter() throws Exception
     {
         request.setupAddParameter("abc", "abc");
@@ -155,7 +155,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertEquals("123", request.getParameterValues("abc")[0]);
         assertEquals("456", request.getParameterValues("abc")[1]);
     }
-    
+
     public void testHeaders()
     {
         request.addHeader("testHeader", "xyz");
@@ -208,7 +208,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertFalse(headers.hasMoreElements());
         assertFalse(request.getHeaders("doesnotexist").hasMoreElements());
     }
-    
+
     public void testHeadersCaseInsensitive()
     {
         request.addHeader("testHeader", "xyz");
@@ -235,7 +235,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertTrue(headerNames.contains("MYHEADER1"));
         assertTrue(headerNames.contains("myHeader2"));
     }
-    
+
     public void testCookies()
     {
         assertNull(request.getCookies());
@@ -251,7 +251,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertEquals("name3", cookies[2].getName());
         assertEquals("value3", cookies[2].getValue());
     }
-    
+
     public void testBodyContent() throws Exception
     {
         request.setBodyContent("test\nanothertest???");
@@ -267,24 +267,24 @@ public class MockHttpServletRequestTest extends TestCase
         assertEquals(127, stream.read());
         assertEquals(55, stream.read());
     }
-    
+
     public void testRequestDispatcher() throws Exception
     {
         final String rdPath1 = "rdPathOne";
         final String rdPath2 = "rdPathTwo";
         final String rdPath3 = "rdPathThree";
-    
+
         assertEquals(0, request.getRequestDispatcherMap().size());
 
         MockRequestDispatcher rd1 = (MockRequestDispatcher)request.getRequestDispatcher(rdPath1);
         assertEquals(rdPath1, rd1.getPath());
         assertNull(rd1.getForwardedRequest());
         assertNull(rd1.getIncludedRequest());
-        
+
         assertEquals(1, request.getRequestDispatcherMap().size());
         assertTrue(request.getRequestDispatcherMap().containsKey(rdPath1));
         assertSame(rd1, request.getRequestDispatcherMap().get(rdPath1));
-        
+
         MockRequestDispatcher actualRd2 = new MockRequestDispatcher();
         request.setRequestDispatcher(rdPath2, actualRd2);
         MockRequestDispatcher rd2 = (MockRequestDispatcher)request.getRequestDispatcher(rdPath2);
@@ -292,24 +292,24 @@ public class MockHttpServletRequestTest extends TestCase
         assertSame(actualRd2, rd2);
         assertNull(rd1.getForwardedRequest());
         assertNull(rd1.getIncludedRequest());
-        
+
         assertEquals(2, request.getRequestDispatcherMap().size());
         assertTrue(request.getRequestDispatcherMap().containsKey(rdPath2));
         assertSame(rd2, request.getRequestDispatcherMap().get(rdPath2));
-        
+
         RequestDispatcher actualRd3 = new TestRequestDispatcher();
         request.setRequestDispatcher(rdPath3, actualRd3);
         RequestDispatcher rd3 = request.getRequestDispatcher(rdPath3);
         assertSame(actualRd3, rd3);
-        
+
         assertEquals(3, request.getRequestDispatcherMap().size());
         assertTrue(request.getRequestDispatcherMap().containsKey(rdPath3));
         assertSame(rd3, request.getRequestDispatcherMap().get(rdPath3));
-        
+
         request.clearRequestDispatcherMap();
         assertEquals(0, request.getRequestDispatcherMap().size());
     }
-    
+
     public void testSessionCreation() throws Exception
     {
         request.setSession(null);
@@ -317,7 +317,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertNull(request.getSession(true));
         assertNull(request.getSession());
         request = new MockHttpServletRequest();
-        MockHttpSession session = new MockHttpSession(); 
+        MockHttpSession session = new MockHttpSession();
         request.setSession(session);
         assertNull(request.getSession(false));
         assertNotNull(request.getSession());
@@ -330,7 +330,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertNotNull(request.getSession(true));
         assertNotNull(request.getSession(false));
     }
-    
+
     public void testSessionInvalidate() throws Exception
     {
         request.setSession(new MockHttpSession());
@@ -338,7 +338,7 @@ public class MockHttpServletRequestTest extends TestCase
         assertFalse(((MockHttpSession)request.getSession(false)).isValid());
         assertTrue(((MockHttpSession)request.getSession(true)).isValid());
     }
-    
+
     public void testIsUserInRole()
     {
         request.setUserInRole("role1", true);
@@ -347,13 +347,13 @@ public class MockHttpServletRequestTest extends TestCase
         assertFalse(request.isUserInRole("role2"));
         assertFalse(request.isUserInRole("role3"));
     }
-    
+
     private class TestAttributeListener implements ServletRequestAttributeListener
     {
         private boolean wasAttributeAddedCalled = false;
         private boolean wasAttributeReplacedCalled = false;
         private boolean wasAttributeRemovedCalled = false;
-    
+
         public void attributeAdded(ServletRequestAttributeEvent event)
         {
             wasAttributeAddedCalled = true;
@@ -368,14 +368,14 @@ public class MockHttpServletRequestTest extends TestCase
         {
             wasAttributeReplacedCalled = true;
         }
-    
+
         public void reset()
         {
             wasAttributeAddedCalled = false;
             wasAttributeReplacedCalled = false;
             wasAttributeRemovedCalled = false;
         }
-    
+
         public boolean wasAttributeAddedCalled()
         {
             return wasAttributeAddedCalled;
@@ -400,7 +400,7 @@ public class MockHttpServletRequestTest extends TestCase
         private Object replacedEventValue;
         private String removedEventKey;
         private Object removedEventValue;
-    
+
         public void attributeAdded(ServletRequestAttributeEvent event)
         {
             addedEventKey = event.getName();
@@ -418,7 +418,7 @@ public class MockHttpServletRequestTest extends TestCase
             replacedEventKey = event.getName();
             replacedEventValue = event.getValue();
         }
-    
+
         public String getAddedEventKey()
         {
             return addedEventKey;
@@ -449,15 +449,15 @@ public class MockHttpServletRequestTest extends TestCase
             return replacedEventValue;
         }
     }
-    
+
     private class TestRequestDispatcher implements RequestDispatcher
     {
-        
+
         public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException
         {
 
         }
-        
+
         public void include(ServletRequest request, ServletResponse response) throws ServletException, IOException
         {
 


### PR DESCRIPTION
This is a fix for issue #62 creating a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) for creating MockHttpServletRequest instances.

The changes are:

1. return this from all setters (and create alternative setters where the interface definition of the method insisted on returning void)
2. added some static methods for creating and populating typical requests for testing REST API 

I tested the changed API in one of my projects and [replaced mockito mocks with MockHttpServletRequest object](https://github.com/steinarb/scratch/commit/7273d270149458e05e704cb5d583192327c4b342).

