### PR TITLE
Upgrade JDOM from 1.0 to 2.0.6.1

### DIFF
--- a/mockrunner-all/pom.xml
+++ b/mockrunner-all/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-all</artifactId>

--- a/mockrunner-all/src/main/java/com/mockrunner/base/HTMLOutputTestCase.java
+++ b/mockrunner-all/src/main/java/com/mockrunner/base/HTMLOutputTestCase.java
@@ -56,7 +56,7 @@ public abstract class HTMLOutputTestCase extends WebTestCase
     /**
      * Delegates to {@link HTMLOutputModule#getOutputAsJDOMDocument}
      */
-    protected org.jdom.Document getOutputAsJDOMDocument()
+    protected org.jdom2.Document getOutputAsJDOMDocument()
     {
         return getHTMLOutputModule().getOutputAsJDOMDocument();
     }

--- a/mockrunner-all/src/test/java/com/mockrunner/test/web/HTMLOutputModuleTest.java
+++ b/mockrunner-all/src/test/java/com/mockrunner/test/web/HTMLOutputModuleTest.java
@@ -17,7 +17,7 @@ import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/mockrunner-core/pom.xml
+++ b/mockrunner-core/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-core</artifactId>
@@ -31,8 +30,8 @@
 		
 		<!-- needed for XML Util -->
 		<dependency>
-			<groupId>jdom</groupId>
-			<artifactId>jdom</artifactId>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom2</artifactId>
 		</dependency>
 		
 		<!-- needed for StringUtil (Perl5Compiler) -->

--- a/mockrunner-core/src/main/java/com/mockrunner/test/util/XmlUtilTest.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/test/util/XmlUtilTest.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
-import org.jdom.Document;
-import org.jdom.Element;
+import org.jdom2.Document;
+import org.jdom2.Element;
 
 import com.mockrunner.util.web.XmlUtil;
 

--- a/mockrunner-core/src/main/java/com/mockrunner/util/web/XmlUtil.java
+++ b/mockrunner-core/src/main/java/com/mockrunner/util/web/XmlUtil.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 import org.apache.xerces.parsers.DOMParser;
 import org.cyberneko.html.HTMLConfiguration;
-import org.jdom.Element;
-import org.jdom.input.DOMBuilder;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Element;
+import org.jdom2.input.DOMBuilder;
+import org.jdom2.output.XMLOutputter;
 import org.xml.sax.InputSource;
 
 import com.mockrunner.base.NestedApplicationException;
@@ -34,10 +34,10 @@ public class XmlUtil
      * </pre>
      * 
      * the method returns the h1 tag as <code>Element</code>.
-     * @param document the <code>org.jdom.Document</code>
+     * @param document the <code>org.jdom2.Document</code>
      * @return the body <code>Element</code>
      */
-    public static Element getBodyFragmentFromJDOMDocument(org.jdom.Document document)
+    public static Element getBodyFragmentFromJDOMDocument(org.jdom2.Document document)
     {
         Element element = document.getRootElement().getChild("BODY");
         if(null == element)
@@ -57,17 +57,17 @@ public class XmlUtil
      * @return the body element
      * @deprecated use {@link #getBodyFragmentFromJDOMDocument}
      */
-    public static Element getBodyFragmentJDOMDocument(org.jdom.Document document)
+    public static Element getBodyFragmentJDOMDocument(org.jdom2.Document document)
     {
         return getBodyFragmentFromJDOMDocument(document);
     }
     
     /**
      * Returns the documents XML content as a string.
-     * @param document the <code>org.jdom.Document</code>
+     * @param document the <code>org.jdom2.Document</code>
      * @return the output as string
      */
-    public static String createStringFromJDOMDocument(org.jdom.Document document)
+    public static String createStringFromJDOMDocument(org.jdom2.Document document)
     {
         try
         {
@@ -83,9 +83,9 @@ public class XmlUtil
      * Creates a JDOM <code>Document</code> from a specified
      * W3C <code>Document</code>.
      * @param document the <code>org.w3c.dom.Document</code>
-     * @return the <code>org.jdom.Document</code>
+     * @return the <code>org.jdom2.Document</code>
      */
-    public static org.jdom.Document createJDOMDocument(org.w3c.dom.Document document)
+    public static org.jdom2.Document createJDOMDocument(org.w3c.dom.Document document)
     {
         return new DOMBuilder().build(document);
     }

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-ejb</artifactId>

--- a/mockrunner-jca/pom.xml
+++ b/mockrunner-jca/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-jca</artifactId>

--- a/mockrunner-jdbc/pom.xml
+++ b/mockrunner-jdbc/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-jdbc</artifactId>

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/XMLResultSetFactory.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/XMLResultSetFactory.java
@@ -7,9 +7,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.input.SAXBuilder;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
 
 import com.mockrunner.base.NestedApplicationException;
 import com.mockrunner.mock.jdbc.MockResultSet;

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/XMLResultSetFactorySQLDeveloperSupport.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/jdbc/XMLResultSetFactorySQLDeveloperSupport.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.input.SAXBuilder;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
 
 import com.mockrunner.base.NestedApplicationException;
 import com.mockrunner.mock.jdbc.MockResultSet;

--- a/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockSQLXML.java
+++ b/mockrunner-jdbc/src/main/java/com/mockrunner/mock/jdbc/MockSQLXML.java
@@ -32,13 +32,13 @@ import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import org.jdom.Document;
-import org.jdom.input.DOMBuilder;
-import org.jdom.input.SAXBuilder;
-import org.jdom.input.SAXHandler;
-import org.jdom.output.DOMOutputter;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.input.DOMBuilder;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.input.sax.SAXHandler;
+import org.jdom2.output.DOMOutputter;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
@@ -146,6 +146,7 @@ public class MockSQLXML implements SQLXML, Cloneable
     
     protected SAXBuilder createJDOMSAXBuilder()
     {
+
         SAXBuilder builder = new SAXBuilder();
         builder.setValidation(false);
         return builder;

--- a/mockrunner-jdbc/src/test/java/com/mockrunner/test/jdbc/MockSQLXMLTest.java
+++ b/mockrunner-jdbc/src/test/java/com/mockrunner/test/jdbc/MockSQLXMLTest.java
@@ -24,11 +24,11 @@ import javax.xml.transform.stream.StreamSource;
 
 import junit.framework.TestCase;
 
-import org.jdom.Document;
-import org.jdom.input.DOMBuilder;
-import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.input.DOMBuilder;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 

--- a/mockrunner-jms-spring/pom.xml
+++ b/mockrunner-jms-spring/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-jms-spring</artifactId>

--- a/mockrunner-jms/pom.xml
+++ b/mockrunner-jms/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-jms</artifactId>

--- a/mockrunner-servlet/pom.xml
+++ b/mockrunner-servlet/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-servlet</artifactId>

--- a/mockrunner-servlet/src/main/java/com/mockrunner/base/BasicHTMLOutputTestCase.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/base/BasicHTMLOutputTestCase.java
@@ -56,7 +56,7 @@ public abstract class BasicHTMLOutputTestCase extends BasicWebTestCase
     /**
      * Delegates to {@link HTMLOutputModule#getOutputAsJDOMDocument}
      */
-    protected org.jdom.Document getOutputAsJDOMDocument()
+    protected org.jdom2.Document getOutputAsJDOMDocument()
     {
         return getHTMLOutputModule().getOutputAsJDOMDocument();
     }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/base/HTMLOutputModule.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/base/HTMLOutputModule.java
@@ -66,10 +66,10 @@ public abstract class HTMLOutputModule extends WebTestModule
      * to parse the string output yourself. Please note that
      * HTML parsing is not very fast and may slow down
      * your test suite.
-     * @return the output as <code>org.jdom.Document</code>
+     * @return the output as <code>org.jdom2.Document</code>
      * @throws RuntimeException if a parsing error occurs
      */
-    public org.jdom.Document getOutputAsJDOMDocument()
+    public org.jdom2.Document getOutputAsJDOMDocument()
     {
         return XmlUtil.createJDOMDocument(getOutputAsW3CDocument());
     }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/example/servlet/RedirectServletTest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/example/servlet/RedirectServletTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/mockrunner-tag/pom.xml
+++ b/mockrunner-tag/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>com.mockrunner</groupId>
 		<artifactId>mockrunner</artifactId>
 		<version>2.0.7-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>mockrunner-tag</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,9 +147,9 @@
                 <version>2.0.8</version>
             </dependency>
             <dependency>
-                <groupId>jdom</groupId>
-                <artifactId>jdom</artifactId>
-                <version>1.0</version>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom2</artifactId>
+                <version>2.0.6.1</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -493,7 +493,7 @@
                 </os>
             </activation>
             <properties>
-                <javadoc-executable-path>/usr/bin/javadoc</javadoc-executable-path>
+                <javadoc-executable-path>${env.JAVA_HOME}/bin/javadoc</javadoc-executable-path>
             </properties>
         </profile>
         <profile>
@@ -505,7 +505,7 @@
                 </os>
             </activation>
             <properties>
-                <javadoc-executable-path>/usr/bin/javadoc</javadoc-executable-path>
+                <javadoc-executable-path>${env.JAVA_HOME}/bin/javadoc</javadoc-executable-path>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
This upgrade fixes warnings in IntelliJ IDEA about the CVE-2021-33813 in the JDOM 1.0 dependency.

The <relativePath> tags are redundant and cause issues in IntelliJ IDEA. It is also better to use JAVA_HOME instead of /usr/bin as javadoc may not always be symlinked to a Java 8 JDK causing compilation issues.