### PR TITLE
Java17 build fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/mockrunner-all/pom.xml
+++ b/mockrunner-all/pom.xml
@@ -104,6 +104,10 @@
 			<groupId>jboss</groupId>
 			<artifactId>jboss-j2ee</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.spec.javax.rmi</groupId>
+			<artifactId>jboss-rmi-api_1.0_spec</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -153,7 +157,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>release-module-exclusives</id>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -42,6 +42,11 @@
 			<version>3.3.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.jacorb</groupId>
+			<artifactId>jacorb</artifactId>
+			<version>3.9</version>
+		</dependency>
+		<dependency>
 			<groupId>jboss</groupId>
 			<artifactId>jboss-j2ee</artifactId>
 			<optional>true</optional>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -35,6 +35,11 @@
 			<artifactId>jboss-j2ee</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.spec.javax.rmi</groupId>
+			<artifactId>jboss-rmi-api_1.0_spec</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -77,7 +82,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>release-module-exclusives</id>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -91,6 +91,13 @@
 					<additionalOptions>-Xdoclint:none</additionalOptions>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+					<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -29,6 +29,17 @@
 		<dependency>
 			<groupId>org.mockejb</groupId>
 			<artifactId>mockejb</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>cglib</groupId>
+					<artifactId>cglib-full</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>cglib</groupId>
+			<artifactId>cglib-nodep</artifactId>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jboss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
                 <version>4.2.2.GA</version>
             </dependency>
             <dependency>
+                <groupId>org.jboss.spec.javax.rmi</groupId>
+                <artifactId>jboss-rmi-api_1.0_spec</artifactId>
+                <version>1.0.6.Final</version>
+            </dependency>
+            <dependency>
                 <groupId>oro</groupId>
                 <artifactId>oro</artifactId>
                 <version>2.0.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             <timezone>Europe/Berlin</timezone>
         </developer>
     </developers>
-	
+
     <contributors>
         <contributor>
             <name>Steinar Bang</name>
@@ -316,7 +316,7 @@
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>4.1.7</version>
+                    <version>4.4.6</version>
                     <extensions>true</extensions>
                     <configuration>
                         <startLevel>80</startLevel>
@@ -429,7 +429,7 @@
 
             </plugins>
         </pluginManagement>
-		
+
         <plugins>
             <plugin>
                 <!-- Also generate a jar for the test binaries when packaging a jar module -->
@@ -572,7 +572,7 @@
 
     <modules>
         <module>mockrunner-core</module>
-        <!-- These modules are not supported at the moment 
+        <!-- These modules are not supported at the moment
        <module>mockrunner-j2ee_1_3</module>
        <module>mockrunner-j2ee_1_4</module>
        <module>mockrunner-jdk_1_3</module>


### PR DESCRIPTION
These are the changes neccessary to make the current master build with OpenJDK java 17 on debian 12.5 "bookworkm"