### PR TITLE
Fix readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,6 @@
 Mockrunner - mock classes for enterprise application testing
 ============================================================
 
-> [!NOTE]
-> This is the repository where the conversion from subversion to git was done, but is no longer actively used in development
-> Development of mockrunner now takes place in https://github.com/mockrunner/mockrunner
-
 FYI: Older 1.1.x branch with support for Java 6 has been moved to "Best Effort" support as we prepare to update for Java 8. If you need support on a feature with that version, feel free to open an issue and we will try to address it as time allows, but our primary focus will be on updating for newer specs on Java 8/9.
 
 Documentation

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Mockrunner - mock classes for enterprise application testing
 ============================================================
 
-FYI: Older 1.1.x branch with support for Java 6 has been moved to "Best Effort" support as we prepare to update for Java 8. If you need support on a feature with that version, feel free to open an issue and we will try to address it as time allows, but our primary focus will be on updating for newer specs on Java 8/9.
+FYI: Older 1.1.x branch with support for Java 6 has been moved to "Best Effort" support. If you need support on a feature with that version, feel free to open an issue and we will try to address it as time allows.
 
 Documentation
 -------------


### PR DESCRIPTION
I messed up the README when merging the MR so this reverts that.

Also I removed what seems like outdated mention of java 8 and java 9 from 2017.