### PR TITLE
Upgrade javax servlet fixes #90

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B -X -e package --file pom.xml
+      run: mvn -B package --file pom.xml
     - name: Store JVM Crash and Surefire Logs
       if: always() # Forces this step to run even if the Maven build fails
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B -X -e package --file pom.xml
     - name: Store JVM Crash and Surefire Logs
       if: always() # Forces this step to run even if the Maven build fails
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,6 @@ jobs:
           **/hs_err_pid*.log
           **/target/surefire-reports/*.dump*
           **/target/surefire-reports/*.txt
+    - name: Check System Logs for Memory (OOM) Kills
+      if: always()
+      run: dmesg | grep -i -E 'oom[-_]killer|killed process' || echo "No OS-level OOM kills detected."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,12 @@ jobs:
         java-version: 1.8
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+    - name: Store JVM Crash and Surefire Logs
+      if: always() # Forces this step to run even if the Maven build fails
+      uses: actions/upload-artifact@v4
+      with:
+        name: maven-crash-logs
+        path: |
+          **/hs_err_pid*.log
+          **/target/surefire-reports/*.dump*
+          **/target/surefire-reports/*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.project
 /.settings/
 /.DS_Store
+/.metadata/

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -1,143 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.mockrunner</groupId>
-		<artifactId>mockrunner</artifactId>
-		<version>2.0.8-SNAPSHOT</version>
-	</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.mockrunner</groupId>
+        <artifactId>mockrunner</artifactId>
+        <version>2.0.8-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>mockrunner-ejb</artifactId>
-	<name>MockRunner-EJB</name>
-	<description>Mock classes for enterprise java beans</description>
+    <artifactId>mockrunner-ejb</artifactId>
+    <name>MockRunner-EJB</name>
+    <description>Mock classes for enterprise java beans</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.mockrunner</groupId>
-			<artifactId>mockrunner-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.mockejb</groupId>
-			<artifactId>mockejb</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>cglib</groupId>
-					<artifactId>cglib-full</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib-nodep</artifactId>
-			<version>3.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jacorb</groupId>
-			<artifactId>jacorb</artifactId>
-			<version>3.9</version>
-		</dependency>
-		<dependency>
-			<groupId>jboss</groupId>
-			<artifactId>jboss-j2ee</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.spec.javax.rmi</groupId>
-			<artifactId>jboss-rmi-api_1.0_spec</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockejb</groupId>
+            <artifactId>mockejb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>cglib</groupId>
+                    <artifactId>cglib-full</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jacorb</groupId>
+            <artifactId>jacorb</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>jboss</groupId>
+            <artifactId>jboss-j2ee</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.rmi</groupId>
+            <artifactId>jboss-rmi-api_1.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<!-- Generate a jar for the source files when deploying -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<!-- Generate a jar for the javadocs when deploying -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadoc</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<javadocExecutable>${javadoc-executable-path}</javadocExecutable>
-					<charset>${project.build.sourceEncoding}</charset>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<docencoding>${project.build.sourceEncoding}</docencoding>
-					<doclint>none</doclint>
-					<additionalOptions>-Xdoclint:none</additionalOptions>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Generate a jar for the source files when deploying -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- Generate a jar for the javadocs when deploying -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadoc</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <javadocExecutable>${javadoc-executable-path}</javadocExecutable>
+                    <charset>${project.build.sourceEncoding}</charset>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <docencoding>${project.build.sourceEncoding}</docencoding>
+                    <doclint>none</doclint>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-					<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 
-	<profiles>
-		<profile>
-			<id>release-module-exclusives</id>
-			<!-- Profile automatically triggered when release:perform is executed -->
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.github.github</groupId>
-						<artifactId>site-maven-plugin</artifactId>
-						<configuration>
-							<path>${project.artifactId}</path>
-							<message>Ejb Site</message>
-						</configuration>
-						<executions>
-							<execution>
-								<id>github-site</id>
-								<goals>
-									<goal>site</goal>
-								</goals>
-								<phase>site</phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+    <profiles>
+        <profile>
+            <id>release-module-exclusives</id>
+            <!-- Profile automatically triggered when release:perform is executed -->
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.github</groupId>
+                        <artifactId>site-maven-plugin</artifactId>
+                        <configuration>
+                            <path>${project.artifactId}</path>
+                            <message>Ejb Site</message>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>github-site</id>
+                                <goals>
+                                    <goal>site</goal>
+                                </goals>
+                                <phase>site</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -100,7 +100,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -101,6 +101,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                    <forkCount>0</forkCount>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
         </plugins>

--- a/mockrunner-jms-spring/pom.xml
+++ b/mockrunner-jms-spring/pom.xml
@@ -50,8 +50,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>servlet-api</artifactId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -136,7 +136,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>release-module-exclusives</id>

--- a/mockrunner-jms/pom.xml
+++ b/mockrunner-jms/pom.xml
@@ -29,8 +29,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>servlet-api</artifactId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -79,7 +79,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>release-module-exclusives</id>

--- a/mockrunner-servlet/pom.xml
+++ b/mockrunner-servlet/pom.xml
@@ -33,8 +33,8 @@
 			<artifactId>commons-logging</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>servlet-api</artifactId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockAsyncContext.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockAsyncContext.java
@@ -1,0 +1,102 @@
+package com.mockrunner.mock.web;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+public class MockAsyncContext implements AsyncContext {
+
+	private ServletRequest request;
+	private ServletResponse response;
+	private boolean hasOriginalRequestAndResponse;
+	private long timeout;
+
+	@Override
+	public ServletRequest getRequest() {
+		return request;
+	}
+
+	public MockAsyncContext setRequest(ServletRequest request) {
+		this.request = request;
+		return this;
+	}
+
+	@Override
+	public ServletResponse getResponse() {
+		return response;
+	}
+
+	public MockAsyncContext setResponse(ServletResponse response) {
+		this.response = response;
+		return this;
+	}
+
+	@Override
+	public boolean hasOriginalRequestAndResponse() {
+		return hasOriginalRequestAndResponse;
+	}
+
+	public MockAsyncContext setHasOriginalRequestAndResponse(boolean hasOriginalRequestAndResponse) {
+		this.hasOriginalRequestAndResponse = hasOriginalRequestAndResponse;
+		return this;
+	}
+
+	@Override
+	public void dispatch() {
+		// No-op
+	}
+
+	@Override
+	public void dispatch(String path) {
+		// No-op
+	}
+
+	@Override
+	public void dispatch(ServletContext context, String path) {
+		// No-op
+	}
+
+	@Override
+	public void complete() {
+		// No-op
+	}
+
+	@Override
+	public void start(Runnable run) {
+		// No-op
+	}
+
+	@Override
+	public void addListener(AsyncListener listener) {
+		// No-op
+	}
+
+	@Override
+	public void addListener(AsyncListener listener, ServletRequest servletRequest, ServletResponse servletResponse) {
+		// No-op
+	}
+
+	@Override
+	public <T extends AsyncListener> T createListener(Class<T> clazz) throws ServletException {
+		return (T) new MockAsyncListener();
+	}
+
+	@Override
+	public void setTimeout(long timeout) {
+		this.timeout = timeout;
+	}
+
+	public MockAsyncContext setTimeoutFluent(long timeout) {
+		this.timeout = timeout;
+		return this;
+	}
+
+	@Override
+	public long getTimeout() {
+		return timeout;
+	}
+
+}

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockAsyncListener.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockAsyncListener.java
@@ -1,0 +1,31 @@
+package com.mockrunner.mock.web;
+
+import java.io.IOException;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+
+public class MockAsyncListener implements AsyncListener {
+
+	@Override
+	public void onComplete(AsyncEvent event) throws IOException {
+		// No-op
+	}
+
+	@Override
+	public void onTimeout(AsyncEvent event) throws IOException {
+		// No-op
+	}
+
+	@Override
+	public void onError(AsyncEvent event) throws IOException {
+		// No-op
+
+	}
+
+	@Override
+	public void onStartAsync(AsyncEvent event) throws IOException {
+		// No-op
+	}
+
+}

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockDynamic.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockDynamic.java
@@ -1,0 +1,101 @@
+package com.mockrunner.mock.web;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.ServletRegistration.Dynamic;
+import javax.servlet.ServletSecurityElement;
+
+public class MockDynamic implements Dynamic {
+    HashSet<String> mappings = new HashSet<>();
+    private String runAsRole;
+    private String name;
+    private Map<String, String> initParameters = new HashMap<>();
+
+    @Override
+    public Set<String> addMapping(String... urlPatterns) {
+        for (String pattern : urlPatterns) {
+            mappings.add(pattern);
+        }
+
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<String> getMappings() {
+        return mappings;
+    }
+
+    @Override
+    public String getRunAsRole() {
+        return runAsRole;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public MockDynamic setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public String getClassName() {
+        return null;
+    }
+
+    @Override
+    public boolean setInitParameter(String name, String value) {
+        initParameters.put(name, value);
+        return true;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return initParameters.get(name);
+    }
+
+    @Override
+    public Set<String> setInitParameters(Map<String, String> initParameters) {
+        this.initParameters.putAll(initParameters);
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Map<String, String> getInitParameters() {
+        return initParameters;
+    }
+
+    @Override
+    public void setAsyncSupported(boolean isAsyncSupported) {
+        // No-op
+    }
+
+    @Override
+    public void setLoadOnStartup(int loadOnStartup) {
+        // No-op
+    }
+
+    @Override
+    public Set<String> setServletSecurity(ServletSecurityElement constraint) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void setMultipartConfig(MultipartConfigElement multipartConfig) {
+        // No-op
+    }
+
+    @Override
+    public void setRunAsRole(String roleName) {
+        runAsRole = roleName;
+    }
+
+}

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterRegistrationDynamic.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterRegistrationDynamic.java
@@ -1,0 +1,86 @@
+package com.mockrunner.mock.web;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration.Dynamic;
+
+public class MockFilterRegistrationDynamic implements Dynamic {
+
+    private String name;
+    private String className;
+    private Map<String, String> initParameters = new HashMap<>();
+
+    @Override
+    public void addMappingForServletNames(EnumSet<DispatcherType> dispatcherTypes, boolean isMatchAfter, String... servletNames) {
+        // No-op
+    }
+
+    @Override
+    public Collection<String> getServletNameMappings() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void addMappingForUrlPatterns(EnumSet<DispatcherType> dispatcherTypes, boolean isMatchAfter, String... urlPatterns) {
+        // No-op
+    }
+
+    @Override
+    public Collection<String> getUrlPatternMappings() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public MockFilterRegistrationDynamic setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    public MockFilterRegistrationDynamic setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    @Override
+    public boolean setInitParameter(String name, String value) {
+        initParameters.put(name, value);
+        return true;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return initParameters.get(name);
+    }
+
+    @Override
+    public Set<String> setInitParameters(Map<String, String> initParameters) {
+        this.initParameters.putAll(initParameters);
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Map<String, String> getInitParameters() {
+        return initParameters;
+    }
+
+    @Override
+    public void setAsyncSupported(boolean isAsyncSupported) {
+        // No-op
+    }
+
+}

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -815,6 +815,12 @@ public class MockHttpServletRequest implements HttpServletRequest
         return this;
     }
 
+    public ServletContext getServletContext()
+    {
+        if(null == session) return new MockServletContext();
+        return session.getServletContext();
+    }
+
     public int getLocalPort()
     {
         return localPort;
@@ -896,11 +902,5 @@ public class MockHttpServletRequest implements HttpServletRequest
                                                                                   value);
             ((ServletRequestAttributeListener) anAttributeListener).attributeRemoved(event);
         }
-    }
-
-    private ServletContext getServletContext()
-    {
-        if(null == session) return new MockServletContext();
-        return session.getServletContext();
     }
 }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -11,6 +11,7 @@ import java.security.Principal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
@@ -18,16 +19,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.Vector;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestAttributeEvent;
 import javax.servlet.ServletRequestAttributeListener;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 import com.mockrunner.base.NestedApplicationException;
 import com.mockrunner.util.common.CaseAwareMap;
@@ -64,6 +74,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     private Map roles;
     private String characterEncoding;
     private int contentLength;
+    private long contentLengthLong;
     private String contentType;
     private List cookies;
     private MockServletInputStream bodyContent;
@@ -74,6 +85,10 @@ public class MockHttpServletRequest implements HttpServletRequest
     private boolean sessionCreated;
     private List attributeListener;
     private boolean isAsyncSupported;
+    private AsyncContext asyncContext;
+    private DispatcherType dispatcherType;
+    private boolean authenticated;
+    private ArrayList<Part> parts = new ArrayList<>();
 
     public MockHttpServletRequest()
     {
@@ -166,6 +181,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         remoteAddr = "127.0.0.1";
         roles = new HashMap();
         contentLength = -1;
+        contentLengthLong = -1L;
         cookies = null;
         localAddr = "127.0.0.1";
         localName = "localhost";
@@ -672,6 +688,16 @@ public class MockHttpServletRequest implements HttpServletRequest
         return this;
     }
 
+    @Override
+    public long getContentLengthLong() {
+        return contentLengthLong;
+    }
+
+    public MockHttpServletRequest setContentLengthLong(long contentLength) {
+        contentLengthLong = contentLength;
+        return this;
+    }
+
     public String getContentType()
     {
         return contentType;
@@ -852,6 +878,94 @@ public class MockHttpServletRequest implements HttpServletRequest
     {
         this.isAsyncSupported = isAsyncSupported;
         return this;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        asyncContext = asyncContext == null ? new MockAsyncContext() : asyncContext;
+        return asyncContext;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        asyncContext = asyncContext == null ? new MockAsyncContext().setRequest(servletRequest).setRequest(servletRequest) : asyncContext;
+        return asyncContext;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return asyncContext != null;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return asyncContext;
+    }
+
+    public MockHttpServletRequest setAsyncContext(AsyncContext asyncContext) {
+        this.asyncContext = asyncContext;
+        return this;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return dispatcherType;
+    }
+
+    public MockHttpServletRequest getDispatcherType(DispatcherType dispatcherType) {
+        this.dispatcherType = dispatcherType;
+        return this;
+    }
+
+    @Override
+    public String changeSessionId() {
+        session = session == null ? new MockHttpSession() : session;
+        if (session instanceof MockHttpSession) {
+            ((MockHttpSession) session).setSessionId(UUID.randomUUID().toString());
+        }
+
+        return session.getId();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return authenticated;
+    }
+
+    public MockHttpServletRequest setAuthenticated(boolean authenticated) {
+        this.authenticated = authenticated;
+        return this;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+        // No-op
+    }
+
+    @Override
+    public void logout() throws ServletException {
+        // No-op
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return parts ;
+    }
+
+    public MockHttpServletRequest setParts(Collection<Part> newParts) {
+        this.parts.clear();
+        this.parts.addAll(newParts);
+        return this;
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return parts.stream().filter(p -> p.getName() == name).findFirst().orElse(null);
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return (T) new MockHttpUpgradeHandler();
     }
 
     private void handleAttributeListenerCalls(String key, Object value, Object oldValue)

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
@@ -176,6 +176,12 @@ public class MockHttpServletResponse implements HttpServletResponse
         setHeader(key, stringValue);
     }
 
+    public void setLongHeader(String key, long value)
+    {
+        String stringValue = Long.toString(value);
+        setHeader(key, stringValue);
+    }
+
     public void setStatus(int code, String message)
     {
         statusCode = code;
@@ -258,7 +264,12 @@ public class MockHttpServletResponse implements HttpServletResponse
     {
         setIntHeader("Content-Length", length);
     }
-    
+
+    @Override
+    public void setContentLengthLong(long len) {
+        setLongHeader("Content-Length", len);
+    }
+
     public String getContentType()
     {
         return getHeader("Content-Type");

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
@@ -102,6 +102,10 @@ public class MockHttpSession implements HttpSession
         return sessionId;
     }
 
+	public void setSessionId(String sessionId) {
+		this.sessionId = sessionId;
+	}
+
     public synchronized Object getValue(String key)
     {
         if (!isValid) throw new IllegalStateException("session invalid");

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpUpgradeHandler.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpUpgradeHandler.java
@@ -1,0 +1,18 @@
+package com.mockrunner.mock.web;
+
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.WebConnection;
+
+public class MockHttpUpgradeHandler implements HttpUpgradeHandler {
+
+	@Override
+	public void init(WebConnection wc) {
+		// No-op
+	}
+
+	@Override
+	public void destroy() {
+		// No-op
+	}
+
+}

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletContext.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletContext.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -15,12 +16,19 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextAttributeEvent;
 import javax.servlet.ServletContextAttributeListener;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+import javax.servlet.ServletRegistration.Dynamic;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import javax.servlet.descriptor.JspConfigDescriptor;
 
 import com.mockrunner.util.common.StreamUtil;
 
@@ -46,6 +54,11 @@ public class MockServletContext implements ServletContext
     private int minorVersion;
     private int effectiveMajorVersion;
     private int effectiveMinorVersion;
+    private Set<SessionTrackingMode> sessionTrackingModes;
+    private String virtualServerName;
+    private int sessonTimeOut;
+    private String requestCharacterSetEncoding;
+    private String responseCharacterSetEncoding;
     
     public MockServletContext()
     {
@@ -454,5 +467,177 @@ public class MockServletContext implements ServletContext
             ServletContextAttributeEvent event = new ServletContextAttributeEvent(this, key, value);
             ((ServletContextAttributeListener) anAttributeListener).attributeRemoved(event);
         }
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, String className) {
+        return new MockDynamic();
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, Servlet servlet) {
+        return new MockDynamic();
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
+        return new MockDynamic();
+    }
+
+    @Override
+    public Dynamic addJspFile(String servletName, String jspFile) {
+        return new MockDynamic();
+    }
+
+    @Override
+    public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
+        try {
+            return clazz.newInstance();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public ServletRegistration getServletRegistration(String servletName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, String className) {
+        return new MockFilterRegistrationDynamic().setName(filterName).setClassName(className);
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
+        return new MockFilterRegistrationDynamic().setName(filterName).setClassName(filter.getClass().getCanonicalName());
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
+        return new MockFilterRegistrationDynamic().setName(filterName).setClassName(filterClass.getCanonicalName());
+    }
+
+    @Override
+    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
+        try {
+            return clazz.newInstance();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public FilterRegistration getFilterRegistration(String filterName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public SessionCookieConfig getSessionCookieConfig() {
+        return new MockSessionCookieConfig();
+    }
+
+    @Override
+    public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
+        this.sessionTrackingModes = sessionTrackingModes;
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        return sessionTrackingModes;
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        return sessionTrackingModes;
+    }
+
+    @Override
+    public void addListener(String className) {
+        // No-op
+    }
+
+    @Override
+    public <T extends EventListener> void addListener(T t) {
+        // No-op
+    }
+
+    @Override
+    public void addListener(Class<? extends EventListener> listenerClass) {
+        // No-op
+    }
+
+    @Override
+    public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
+        try {
+            return clazz.newInstance();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public JspConfigDescriptor getJspConfigDescriptor() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return getClassLoader();
+    }
+
+    @Override
+    public void declareRoles(String... roleNames) {
+        // No-op
+    }
+
+    @Override
+    public String getVirtualServerName() {
+        return virtualServerName;
+    }
+
+    public MockServletContext setVirtualServerName(String virtualServerName) {
+        this.virtualServerName = virtualServerName;
+        return this;
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return sessonTimeOut;
+    }
+
+    @Override
+    public void setSessionTimeout(int sessionTimeout) {
+        this.sessonTimeOut = sessionTimeout;
+    }
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return requestCharacterSetEncoding;
+    }
+
+    @Override
+    public void setRequestCharacterEncoding(String encoding) {
+        this.requestCharacterSetEncoding = encoding;
+    }
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return responseCharacterSetEncoding;
+    }
+
+    @Override
+    public void setResponseCharacterEncoding(String encoding) {
+        this.responseCharacterSetEncoding = encoding;
     }
 }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletInputStream.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletInputStream.java
@@ -3,6 +3,7 @@ package com.mockrunner.mock.web;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 
 /**
@@ -11,14 +12,29 @@ import javax.servlet.ServletInputStream;
 public class MockServletInputStream extends ServletInputStream
 {
     private ByteArrayInputStream stream;
-    
+
     public MockServletInputStream(byte[] data)
     {
         stream = new ByteArrayInputStream(data);
     }
-        
+
     public int read() throws IOException
     {
         return stream.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return stream.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+        return stream.available() > 0;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        // No-op
     }
 }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletOutputStream.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockServletOutputStream.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 
 import com.mockrunner.base.NestedApplicationException;
 
@@ -14,56 +15,66 @@ public class MockServletOutputStream extends ServletOutputStream
 {
     private ByteArrayOutputStream buffer;
     private String encoding;
-    
+
     public MockServletOutputStream()
     {
         this("ISO-8859-1");
     }
-    
+
     public MockServletOutputStream(String encoding)
     {
         buffer = new ByteArrayOutputStream();
         this.encoding = encoding;
     }
-    
+
     public void setEncoding(String encoding)
     {
         this.encoding = encoding;
     }
-    
+
     public void write(int value) throws IOException
     {
         buffer.write(value);
     }
-    
+
     public String getContent()
     {
         try
         {
             buffer.flush();
             return buffer.toString(encoding);
-        } 
+        }
         catch(IOException exc)
         {
             throw new NestedApplicationException(exc);
         }
     }
-    
+
     public byte[] getBinaryContent()
     {
         try
         {
             buffer.flush();
             return buffer.toByteArray();
-        } 
+        }
         catch(IOException exc)
         {
             throw new NestedApplicationException(exc);
         }
     }
-    
+
     public void clearContent()
     {
         buffer = new ByteArrayOutputStream();
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        // No-op
     }
 }

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockSessionCookieConfig.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockSessionCookieConfig.java
@@ -1,10 +1,11 @@
 package com.mockrunner.mock.web;
 
+import javax.servlet.SessionCookieConfig;
 
 /**
  * Mock implementation of <code>SessionCookieConfig</code>.
  */
-public class MockSessionCookieConfig //implements SessionCookieConfig
+public class MockSessionCookieConfig implements SessionCookieConfig
 {
     private String comment;
     private String domain;

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>servlet-api</artifactId>
-                <version>6.0.37</version>
+                <version>6.0.53</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,9 +182,9 @@
                 <version>1.3.04</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>6.0.53</version>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>4.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,11 @@
                         <showDeprecation>true</showDeprecation>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.5</version>
+                </plugin>
 
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This pull request upgrades mockrunner-servlet to the most recent javax.servlet-api before moving to jakarta.servlet-api, i.e. [javax.servlet-api 4.0.1 from April 20 2018](https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api/4.0.1) and fixes the stack trace in https://github.com/mockrunner/mockrunner/issues/90

This pull request is a "minimum energy approach", i.e. just the changes necessary to wedge in a newer javax.servlet-api:

1. Switch the javax.servlet-api maven dependency from tomcat to javax.servlet, because there were no recent enough tomcat dependencies. Didn't touch the other dependencies (would have if things had started failing)
2. Implement missing methods and put in relevant content were obvious (use existing methods and fields where found, add fields where it seemed appropriate (e.g. when there were setter and getter pairs), return null or empty collections where javadoc indicated that as a possibility, marked many methods returning void with no-op comment)
3. No tests, because this is code for use in tests and the tests wouldn't add any value to me and I would have to actually understand methods I will never call on my own and where the javadoc was mind-boggling
4. Switched .editorconfig from tab indent to space indent because that's what the code I modified was using.

@cemartins Could you have a quick look maybe? Thanks!