### PR TITLE
Fix local build with java 21

### DIFF
--- a/mockrunner-ejb/pom.xml
+++ b/mockrunner-ejb/pom.xml
@@ -101,7 +101,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
-                    <forkCount>0</forkCount>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
@@ -136,6 +135,40 @@
                                 <phase>site</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk-8-config</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkCount>0</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk-9-and-later-config</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkCount>1</forkCount>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
The changes made to maven-surefire-plugin config in mockrunner-ejb/pom.xml fixed build problem on Java 1.8 in github actions.

This is an attempt to fix the build of mockrunner-ejb both locally on a recent Java and on github actions with java 1.8