### PR TITLE
Set httprequest headers when setting header values fixes #69

### DIFF
--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterChain.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterChain.java
@@ -20,12 +20,17 @@ import com.mockrunner.base.NestedApplicationException;
  */
 public class MockFilterChain implements FilterChain
 {
+    @SuppressWarnings("rawtypes")
     private List filters = new ArrayList();
     private Servlet servlet;
+    @SuppressWarnings("rawtypes")
     private Iterator iterator;
+    @SuppressWarnings("rawtypes")
     private List requestList = new ArrayList();
+    @SuppressWarnings("rawtypes")
     private List responseList = new ArrayList();
-    
+
+    @SuppressWarnings("unchecked")
     public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException
     {
         requestList.add(request);
@@ -46,7 +51,7 @@ public class MockFilterChain implements FilterChain
             servlet.service(request, response);
         }
     }
-    
+
     /**
      * Resets the internal iterator of this chain.
      */
@@ -59,11 +64,12 @@ public class MockFilterChain implements FilterChain
      * Adds a filter to the chain.
      * @param filter the filter
      */
-    public void addFilter(Filter filter) 
+    @SuppressWarnings("unchecked")
+    public void addFilter(Filter filter)
     {
         filters.add(filter);
     }
-    
+
     /**
      * Adds a filter to the chain. The filter must implement
      * <code>javax.servlet.Filter</code>.
@@ -71,7 +77,8 @@ public class MockFilterChain implements FilterChain
      * @throws IllegalArgumentException if the specified class does not implement
      *         <code>javax.servlet.Filter</code>
      */
-    public void addFilter(Class filterClass) 
+    @SuppressWarnings("unchecked")
+    public void addFilter(@SuppressWarnings("rawtypes") Class filterClass)
     {
         if(!Filter.class.isAssignableFrom(filterClass))
         {
@@ -86,12 +93,12 @@ public class MockFilterChain implements FilterChain
             throw new NestedApplicationException(exc);
         }
     }
-    
+
     /**
      * Sets the servlet that is called at the end of the chain.
      * @param servlet the servlet
      */
-    public void setServlet(Servlet servlet) 
+    public void setServlet(Servlet servlet)
     {
         this.servlet = servlet;
     }
@@ -105,27 +112,29 @@ public class MockFilterChain implements FilterChain
         setServlet(null);
         reset();
     }
-    
+
     /**
      * Returns the list of all request objects used to call
      * {@link #doFilter} when iterating through the chain.
      * @return the request list
      */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public List getRequestList()
     {
         return Collections.unmodifiableList(requestList);
     }
-    
+
     /**
      * Returns the list of all response objects used to call
      * {@link #doFilter} when iterating through the chain.
      * @return the response list
      */
+    @SuppressWarnings("rawtypes")
     public List getResponseList()
     {
-        return Collections.unmodifiableList(responseList);
+        return responseList;
     }
-    
+
     /**
      * Returns the last request, usually the request that was
      * used to call the final servlet. Returns <code>null</code>

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterConfig.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFilterConfig.java
@@ -14,9 +14,11 @@ import javax.servlet.ServletContext;
 public class MockFilterConfig implements FilterConfig
 {
     private ServletContext context;
+    @SuppressWarnings("rawtypes")
     private Map initParameters;
     private String name;
-    
+
+    @SuppressWarnings("rawtypes")
     public MockFilterConfig()
     {
         initParameters = new HashMap();
@@ -35,7 +37,7 @@ public class MockFilterConfig implements FilterConfig
     {
         return name;
     }
-    
+
     public synchronized void setFilterName(String name)
     {
         this.name = name;
@@ -45,7 +47,7 @@ public class MockFilterConfig implements FilterConfig
     {
         return context;
     }
-    
+
     public synchronized void clearInitParameters()
     {
         initParameters.clear();
@@ -58,26 +60,29 @@ public class MockFilterConfig implements FilterConfig
     {
         return (String)initParameters.get(name);
     }
-    
+
     /**
      * Sets an init parameter.
      * @param name the name
      * @param value the value
      */
-    public synchronized void setInitParameter(String name, String value) 
+    @SuppressWarnings("unchecked")
+    public synchronized void setInitParameter(String name, String value)
     {
         initParameters.put(name, value);
     }
-    
+
     /**
      * Sets several init parameters.
      * @param parameters the parameter map
      */
-    public synchronized void setInitParameters(Map parameters) 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public synchronized void setInitParameters(Map parameters)
     {
         initParameters.putAll(parameters);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public synchronized Enumeration getInitParameterNames()
     {
         return new Vector(initParameters.keySet()).elements();

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFunctionMapper.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockFunctionMapper.java
@@ -11,20 +11,22 @@ import javax.servlet.jsp.el.FunctionMapper;
  */
 public class MockFunctionMapper implements FunctionMapper
 {
+    @SuppressWarnings("rawtypes")
     private Map functions = new HashMap();
-    
+
     /**
      * Adds a function for the specified prefix and name.
      * @param prefix the prefix of the function
      * @param localName the name of the function
      * @param function the function as <code>Method</code>
      */
+    @SuppressWarnings("unchecked")
     public void addFunction(String prefix, String localName, Method function)
     {
         FunctionMappingEntry entry = new FunctionMappingEntry(prefix, localName);
         functions.put(entry, function);
     }
-    
+
     /**
      * Clears all functions.
      */
@@ -32,7 +34,7 @@ public class MockFunctionMapper implements FunctionMapper
     {
         functions.clear();
     }
-    
+
     public Method resolveFunction(String prefix, String localName)
     {
         FunctionMappingEntry entry = new FunctionMappingEntry(prefix, localName);

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -47,13 +47,18 @@ import com.mockrunner.util.common.CaseAwareMap;
  */
 public class MockHttpServletRequest implements HttpServletRequest
 {
+    @SuppressWarnings("rawtypes")
     private Map attributes;
+    @SuppressWarnings("rawtypes")
     private Map parameters;
+    @SuppressWarnings("rawtypes")
     private Vector locales;
+    @SuppressWarnings("rawtypes")
     private Map requestDispatchers;
     private HttpSession session;
     private String method;
     private String authType;
+    @SuppressWarnings("rawtypes")
     private Map headers;
     private String contextPath;
     private String pathInfo;
@@ -71,11 +76,13 @@ public class MockHttpServletRequest implements HttpServletRequest
     private String scheme;
     private String remoteHost;
     private String remoteAddr;
+    @SuppressWarnings("rawtypes")
     private Map roles;
     private String characterEncoding;
     private int contentLength;
     private long contentLengthLong;
     private String contentType;
+    @SuppressWarnings("rawtypes")
     private List cookies;
     private MockServletInputStream bodyContent;
     private String localAddr;
@@ -83,6 +90,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     private int localPort;
     private int remotePort;
     private boolean sessionCreated;
+    @SuppressWarnings("rawtypes")
     private List attributeListener;
     private boolean isAsyncSupported;
     private AsyncContext asyncContext;
@@ -168,6 +176,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     /**
      * Resets the state of this object to the default values
      */
+    @SuppressWarnings("rawtypes")
     public void resetAll()
     {
         attributes = new HashMap();
@@ -197,6 +206,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         isAsyncSupported = false;
     }
 
+    @SuppressWarnings("unchecked")
     public MockHttpServletRequest addAttributeListener(ServletRequestAttributeListener listener)
     {
         attributeListener.add(listener);
@@ -234,6 +244,7 @@ public class MockHttpServletRequest implements HttpServletRequest
      * @param values the parameters values
      * @return a reference to the request (fluent API)
      */
+    @SuppressWarnings("unchecked")
     public MockHttpServletRequest setupAddParameter(String key, String[] values)
     {
         parameters.put(key, values);
@@ -252,12 +263,14 @@ public class MockHttpServletRequest implements HttpServletRequest
         return this;
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration getParameterNames()
     {
         Vector parameterKeys = new Vector(parameters.keySet());
         return parameterKeys.elements();
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Map getParameterMap()
     {
         return Collections.unmodifiableMap(parameters);
@@ -274,6 +287,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         return attributes.get(key);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration getAttributeNames()
     {
         Vector attKeys = new Vector(attributes.keySet());
@@ -290,6 +304,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void setAttribute(String key, Object value)
     {
         Object oldValue = attributes.get(key);
@@ -359,6 +374,7 @@ public class MockHttpServletRequest implements HttpServletRequest
      * maps to the corresponding <code>RequestDispatcher</code> object.
      * @return the map of <code>RequestDispatcher</code> objects
      */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Map getRequestDispatcherMap()
     {
         return Collections.unmodifiableMap(requestDispatchers);
@@ -383,6 +399,7 @@ public class MockHttpServletRequest implements HttpServletRequest
      * @param dispatcher the <code>RequestDispatcher</code> object
      * @return a reference to the request (fluent API)
      */
+    @SuppressWarnings("unchecked")
     public MockHttpServletRequest setRequestDispatcher(String path, RequestDispatcher dispatcher)
     {
         if(dispatcher instanceof MockRequestDispatcher)
@@ -399,18 +416,21 @@ public class MockHttpServletRequest implements HttpServletRequest
         return (Locale)locales.get(0);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration getLocales()
     {
         return locales.elements();
     }
 
+    @SuppressWarnings("unchecked")
     public MockHttpServletRequest addLocale(Locale locale)
     {
         locales.add(locale);
         return this;
     }
 
-    public MockHttpServletRequest addLocales(List localeList)
+    @SuppressWarnings("unchecked")
+    public MockHttpServletRequest addLocales(@SuppressWarnings("rawtypes") List localeList)
     {
         locales.addAll(localeList);
         return this;
@@ -455,16 +475,19 @@ public class MockHttpServletRequest implements HttpServletRequest
 
     public String getHeader(String key)
     {
+        @SuppressWarnings("rawtypes")
         List headerList = (List)headers.get(key);
         if(null == headerList || 0 == headerList.size()) return null;
         return (String)headerList.get(0);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration getHeaderNames()
     {
         return new Vector(headers.keySet()).elements();
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration getHeaders(String key)
     {
         List headerList = (List)headers.get(key);
@@ -479,6 +502,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         return new Integer(header);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public MockHttpServletRequest addHeader(String key, String value)
     {
         List valueList = (List) headers.get(key);
@@ -491,8 +515,10 @@ public class MockHttpServletRequest implements HttpServletRequest
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public void setHeader(String key, String value)
     {
+        @SuppressWarnings("rawtypes")
         List valueList = new ArrayList();
         headers.put(key, valueList);
         valueList.add(value);
@@ -603,12 +629,14 @@ public class MockHttpServletRequest implements HttpServletRequest
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public Cookie[] getCookies()
     {
         if(null == cookies) return null;
         return (Cookie[])cookies.toArray(new Cookie[cookies.size()]);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public MockHttpServletRequest addCookie(Cookie cookie)
     {
         if(null == cookies)
@@ -659,6 +687,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         return (Boolean) roles.get(role);
     }
 
+    @SuppressWarnings("unchecked")
     public MockHttpServletRequest setUserInRole(String role, boolean isInRole)
     {
         roles.put(role, isInRole);
@@ -700,6 +729,7 @@ public class MockHttpServletRequest implements HttpServletRequest
 
     public MockHttpServletRequest setContentLengthLong(long contentLength) {
         contentLengthLong = contentLength;
+        setHeader(CONTENT_LENGTH, Long.toString(contentLength));
         return this;
     }
 
@@ -969,6 +999,7 @@ public class MockHttpServletRequest implements HttpServletRequest
         return parts.stream().filter(p -> p.getName() == name).findFirst().orElse(null);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
         return (T) new MockHttpUpgradeHandler();

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -92,6 +92,7 @@ public class MockHttpServletRequest implements HttpServletRequest
 
     // HTTP Header names
     public static final String CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_LENGTH = "Content-Legth";
 
     public MockHttpServletRequest()
     {
@@ -688,6 +689,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     public MockHttpServletRequest setContentLength(int contentLength)
     {
         this.contentLength = contentLength;
+        setHeader(CONTENT_LENGTH, Integer.toString(contentLength));
         return this;
     }
 

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletRequest.java
@@ -90,6 +90,9 @@ public class MockHttpServletRequest implements HttpServletRequest
     private boolean authenticated;
     private ArrayList<Part> parts = new ArrayList<>();
 
+    // HTTP Header names
+    public static final String CONTENT_TYPE = "Content-Type";
+
     public MockHttpServletRequest()
     {
         resetAll();
@@ -706,6 +709,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     public MockHttpServletRequest setContentType(String contentType)
     {
         this.contentType = contentType;
+        setHeader(CONTENT_TYPE, contentType);
         return this;
     }
 

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpServletResponse.java
@@ -28,6 +28,7 @@ public class MockHttpServletResponse implements HttpServletResponse
 {
     private PrintWriter writer;
     private MockServletOutputStream outputStream;
+    @SuppressWarnings("rawtypes")
     private Map headers;
     private Locale locale;
     private String characterEncoding;
@@ -36,6 +37,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     private boolean wasRedirectSent;
     private int errorCode;
     private int statusCode;
+    @SuppressWarnings("rawtypes")
     private List cookies;
 
     public MockHttpServletResponse()
@@ -46,6 +48,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     /**
      * Resets the state of this object to the default values
      */
+    @SuppressWarnings("rawtypes")
     public void resetAll()
     {
         headers = new CaseAwareMap();
@@ -60,7 +63,7 @@ public class MockHttpServletResponse implements HttpServletResponse
         try
         {
             writer = new PrintWriter(new OutputStreamWriter(outputStream, characterEncoding), true);
-        } 
+        }
         catch(UnsupportedEncodingException exc)
         {
             throw new NestedApplicationException(exc);
@@ -107,6 +110,7 @@ public class MockHttpServletResponse implements HttpServletResponse
         return outputStream.getBinaryContent();
     }
 
+    @SuppressWarnings("unchecked")
     public void addCookie(Cookie cookie)
     {
         cookies.add(cookie);
@@ -117,6 +121,7 @@ public class MockHttpServletResponse implements HttpServletResponse
         addHeader(key, getDateString(date));
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public void addHeader(String key, String value)
     {
         List valueList = (List) headers.get(key);
@@ -161,11 +166,13 @@ public class MockHttpServletResponse implements HttpServletResponse
     public void setDateHeader(String key, long date)
     {
         setHeader(key, getDateString(date));
-    } 
+    }
 
+    @SuppressWarnings("unchecked")
     public void setHeader(String key, String value)
     {
-        List valueList = new ArrayList();
+        @SuppressWarnings("rawtypes")
+            List valueList = new ArrayList();
         headers.put(key, valueList);
         valueList.add(value);
     }
@@ -215,7 +222,7 @@ public class MockHttpServletResponse implements HttpServletResponse
         try
         {
             writer = new PrintWriter(new OutputStreamWriter(outputStream, characterEncoding), true);
-        } 
+        }
         catch(UnsupportedEncodingException exc)
         {
             throw new NestedApplicationException(exc);
@@ -236,7 +243,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     {
         return false;
     }
-    
+
     public void reset()
     {
         errorCode = SC_OK;
@@ -249,7 +256,7 @@ public class MockHttpServletResponse implements HttpServletResponse
     {
         outputStream.clearContent();
     }
-    
+
     public void clearHeaders()
     {
         headers.clear();
@@ -279,61 +286,66 @@ public class MockHttpServletResponse implements HttpServletResponse
     {
         setHeader("Content-Type", type);
     }
-    
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getHeaderNames()
     {
         return headers.keySet();
     }
-    
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getHeaders(String name)
     {
         List headerList = (List)headers.get(name);
         if(null == headerList) return null;
         return headerList;
     }
-    
+
+    @SuppressWarnings("rawtypes")
     public List getHeaderList(String key)
     {
         return (List)headers.get(key);
     }
-    
+
+    @SuppressWarnings("rawtypes")
     public String getHeader(String key)
     {
         List list = getHeaderList(key);
         if(null == list || 0 == list.size()) return null;
         return (String)list.get(0);
     }
-    
+
     public int getStatusCode()
     {
         return statusCode;
     }
-    
+
     public int getStatus()
     {
         return getStatusCode();
     }
-    
+
     public int getErrorCode()
     {
         return errorCode;
     }
-    
+
+    @SuppressWarnings("rawtypes")
     public List getCookies()
     {
         return cookies;
     }
-    
+
     public boolean wasErrorSent()
     {
         return wasErrorSent;
     }
-    
+
     public boolean wasRedirectSent()
     {
         return wasRedirectSent;
     }
-    
+
     private String getDateString(long date)
     {
         Date dateValue = new Date(date);

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockHttpSession.java
@@ -3,7 +3,6 @@ package com.mockrunner.mock.web;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -20,6 +19,7 @@ import javax.servlet.http.HttpSessionContext;
  */
 public class MockHttpSession implements HttpSession
 {
+    @SuppressWarnings("rawtypes")
     private HashMap attributes;
     private String sessionId;
     private boolean isNew;
@@ -27,16 +27,18 @@ public class MockHttpSession implements HttpSession
     private long creationTime;
     private ServletContext servletContext;
     private int maxInactiveInterval;
+    @SuppressWarnings("rawtypes")
     private List attributeListener;
 
     public MockHttpSession()
     {
         resetAll();
     }
-    
+
     /**
      * Resets the state of this object to the default values
      */
+    @SuppressWarnings("rawtypes")
     public synchronized void resetAll()
     {
         attributes = new HashMap();
@@ -47,6 +49,7 @@ public class MockHttpSession implements HttpSession
         attributeListener = new ArrayList();
     }
 
+    @SuppressWarnings("unchecked")
     public synchronized void addAttributeListener(HttpSessionAttributeListener listener)
     {
         attributeListener.add(listener);
@@ -65,7 +68,7 @@ public class MockHttpSession implements HttpSession
     {
         return servletContext;
     }
-    
+
     public synchronized boolean isValid()
     {
         return isValid;
@@ -87,10 +90,12 @@ public class MockHttpSession implements HttpSession
         return creationTime;
     }
 
+    @SuppressWarnings("unchecked")
     public synchronized void invalidate()
     {
         if (!isValid) throw new IllegalStateException("session invalid");
         isValid = false;
+        @SuppressWarnings("rawtypes")
         Map clone = new HashMap(attributes);
         for (Object o : clone.keySet()) {
             doRemoveAttribute((String) o);
@@ -112,9 +117,11 @@ public class MockHttpSession implements HttpSession
         return getAttribute(key);
     }
 
+    @SuppressWarnings("unchecked")
     public synchronized String[] getValueNames()
     {
         if (!isValid) throw new IllegalStateException("session invalid");
+        @SuppressWarnings("rawtypes")
         Vector attKeys = new Vector(attributes.keySet());
         return (String[]) attKeys.toArray();
     }
@@ -130,7 +137,7 @@ public class MockHttpSession implements HttpSession
         if (!isValid) throw new IllegalStateException("session invalid");
         removeAttribute(key);
     }
-    
+
     public synchronized void clearAttributes()
     {
         attributes.clear();
@@ -142,6 +149,7 @@ public class MockHttpSession implements HttpSession
         return attributes.get(key);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public synchronized Enumeration getAttributeNames()
     {
         if (!isValid) throw new IllegalStateException("session invalid");
@@ -166,10 +174,11 @@ public class MockHttpSession implements HttpSession
         }
     }
 
+    @SuppressWarnings("unchecked")
     public synchronized void setAttribute(String key, Object value)
     {
         if (!isValid) throw new IllegalStateException("session invalid");
-        Object oldValue = attributes.get(key); 
+        Object oldValue = attributes.get(key);
         if(null == value)
         {
             attributes.remove(key);
@@ -213,15 +222,15 @@ public class MockHttpSession implements HttpSession
             {
                 callAttributeListenersAddedMethod(key, value);
             }
-        
+
         }
     }
-    
+
     public synchronized long getLastAccessedTime()
     {
         return System.currentTimeMillis();
     }
-    
+
     public synchronized void setMaxInactiveInterval(int maxInactiveInterval)
     {
         this.maxInactiveInterval = maxInactiveInterval;
@@ -236,7 +245,7 @@ public class MockHttpSession implements HttpSession
     {
         return new MockSessionContext();
     }
-    
+
     private synchronized void callAttributeListenersAddedMethod(String key, Object value)
     {
         for (Object anAttributeListener : attributeListener) {

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockJspConfigDescriptor.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockJspConfigDescriptor.java
@@ -6,40 +6,45 @@ import java.util.List;
 
 public class MockJspConfigDescriptor // implements JspConfigDescriptor
 {
+    @SuppressWarnings("rawtypes")
     private List jspPropertyGroups;
+    @SuppressWarnings("rawtypes")
     private List taglibs;
-    
+
     public MockJspConfigDescriptor()
     {
         reset();
     }
-    
+
+    @SuppressWarnings("rawtypes")
     public void reset()
     {
         jspPropertyGroups = new ArrayList();
         taglibs = new ArrayList();
     }
-    
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getJspPropertyGroups()
     {
         return new ArrayList(jspPropertyGroups);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getTaglibs()
     {
         return new ArrayList(taglibs);
     }
 
     /*
-      Adds a <code>JspPropertyGroupDescriptor</code> to the list of JSP property groups.
+    Adds a <code>JspPropertyGroupDescriptor</code> to the list of JSP property groups.
 
       @param jspPropertyGroup the <code>JspPropertyGroupDescriptor</code> to add
      */
-//    public void addJspPropertyGroup(JspPropertyGroupDescriptor jspPropertyGroup)
-//    {
-//        this.jspPropertyGroups.add(jspPropertyGroup);
-//    }
-    
+    //    public void addJspPropertyGroup(JspPropertyGroupDescriptor jspPropertyGroup)
+    //    {
+    //        this.jspPropertyGroups.add(jspPropertyGroup);
+    //    }
+
     /**
      * Clears the list of JSP property groups.
      */
@@ -47,17 +52,17 @@ public class MockJspConfigDescriptor // implements JspConfigDescriptor
     {
         this.jspPropertyGroups.clear();
     }
-    
+
     /*
-      Adds a <code>TaglibDescriptor</code> to the list of taglibs.
+    Adds a <code>TaglibDescriptor</code> to the list of taglibs.
 
       @param taglib the <code>TaglibDescriptor</code> to add
      */
-//    public void addTaglib(TaglibDescriptor taglib)
-//    {
-//        this.taglibs.add(taglib);
-//    }
-    
+    //    public void addTaglib(TaglibDescriptor taglib)
+    //    {
+    //        this.taglibs.add(taglib);
+    //    }
+
     /**
      * Clears the list of taglibs.
      */

--- a/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockJspPropertyGroupDescriptor.java
+++ b/mockrunner-servlet/src/main/java/com/mockrunner/mock/web/MockJspPropertyGroupDescriptor.java
@@ -14,19 +14,23 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
     private String deferredSyntaxAllowedAsLiteral;
     private String elIgnored;
     private String errorOnUndeclaredNamespace;
+    @SuppressWarnings("rawtypes")
     private List includeCodas;
+    @SuppressWarnings("rawtypes")
     private List includePreludes;
     private String isXml;
     private String pageEncoding;
     private String scriptingInvalid;
     private String trimDirectiveWhitespaces;
+    @SuppressWarnings("rawtypes")
     private Collection urlPatterns;
-    
+
     public MockJspPropertyGroupDescriptor()
     {
         reset();
     }
-    
+
+    @SuppressWarnings("rawtypes")
     public void reset()
     {
         buffer = "8kb";
@@ -68,11 +72,13 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
         return errorOnUndeclaredNamespace;
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getIncludeCodas()
     {
         return new ArrayList(includeCodas);
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getIncludePreludes()
     {
         return new ArrayList(includePreludes);
@@ -98,6 +104,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
         return trimDirectiveWhitespaces;
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Collection getUrlPatterns()
     {
         return new ArrayList(urlPatterns);
@@ -105,7 +112,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets the buffer size.
-     * 
+     *
      * @param buffer the buffer size
      */
     public void setBuffer(String buffer)
@@ -115,7 +122,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets the default content type.
-     * 
+     *
      * @param defaultContentType the default content type
      */
     public void setDefaultContentType(String defaultContentType)
@@ -125,7 +132,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if the deferred character sequence is allowed as literal text.
-     * 
+     *
      * @param deferredSyntaxAllowedAsLiteral is the deferred character sequence allowed as literal text
      */
     public void setDeferredSyntaxAllowedAsLiteral(String deferredSyntaxAllowedAsLiteral)
@@ -135,7 +142,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if EL evaluation is disabled or enabled.
-     * 
+     *
      * @param elIgnored is EL evaluation disabled or enabled
      */
     public void setElIgnored(String elIgnored)
@@ -145,24 +152,25 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if an error should be raised on undeclared namespace.
-     * 
+     *
      * @param errorOnUndeclaredNamespace should an error should be raised on undeclared namespace
      */
     public void setErrorOnUndeclaredNamespace(String errorOnUndeclaredNamespace)
     {
         this.errorOnUndeclaredNamespace = errorOnUndeclaredNamespace;
     }
-    
+
     /**
      * Adds an include coda to the collection of include codas.
-     * 
+     *
      * @param includeCode the include coda to add
      */
+    @SuppressWarnings("unchecked")
     public void addIncludeCoda(String includeCode)
     {
         this.includeCodas.add(includeCode);
     }
-    
+
     /**
      * Clears the collection of include codas.
      */
@@ -170,17 +178,18 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
     {
         this.includeCodas.clear();
     }
-    
+
     /**
      * Adds an include prelude to the collection of include preludes.
-     * 
+     *
      * @param includePrelude the include prelude to add
      */
+    @SuppressWarnings("unchecked")
     public void addIncludePrelude(String includePrelude)
     {
         this.includePreludes.add(includePrelude);
     }
-    
+
     /**
      * Clears the collection of include preludes.
      */
@@ -191,7 +200,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if it is an XML JSP document.
-     * 
+     *
      * @param isXml is it an XML JSP document
      */
     public void setIsXml(String isXml)
@@ -201,7 +210,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets the page encoding.
-     * 
+     *
      * @param pageEncoding the page encoding
      */
     public void setPageEncoding(String pageEncoding)
@@ -211,7 +220,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if scripting is invalid.
-     * 
+     *
      * @param scriptingInvalid is scripting invalid
      */
     public void setScriptingInvalid(String scriptingInvalid)
@@ -221,7 +230,7 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Sets if directive whitespaces should be trimmed.
-     * 
+     *
      * @param trimDirectiveWhitespaces should directive whitespaces be trimmed
      */
     public void setTrimDirectiveWhitespaces(String trimDirectiveWhitespaces)
@@ -231,14 +240,15 @@ public class MockJspPropertyGroupDescriptor // implements JspPropertyGroupDescri
 
     /**
      * Adds an URL pattern to the collection of URL patterns.
-     * 
+     *
      * @param urlPattern the URL pattern to add
      */
+    @SuppressWarnings("unchecked")
     public void addUrlPattern(String urlPattern)
     {
         this.urlPatterns.add(urlPattern);
     }
-    
+
     /**
      * Clears the collection of URL patterns.
      */

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
@@ -513,6 +513,20 @@ class MockHttpServletRequestTest
         assertThat(request.getHeader(MockHttpServletRequest.CONTENT_TYPE)).isEqualTo(contentType);
     }
 
+    @Test
+    void testThatSetContentLengthAlsoSetsHeaderValue() {
+        int contentLEngth = 30445;
+        MockHttpServletRequest request = new MockHttpServletRequest().setContentLength(contentLEngth);
+        assertThat(request.getHeader(MockHttpServletRequest.CONTENT_LENGTH)).isEqualTo(Integer.toString(contentLEngth));
+    }
+
+    @Test
+    void testThatSetContentLengthLongAlsoSetsHeaderValue() {
+        long contentLEngth = 30447L;
+        MockHttpServletRequest request = new MockHttpServletRequest().setContentLengthLong(contentLEngth);
+        assertThat(request.getHeader(MockHttpServletRequest.CONTENT_LENGTH)).isEqualTo(Long.toString(contentLEngth));
+    }
+
     private class TestAttributeListener implements ServletRequestAttributeListener {
         private boolean wasAttributeAddedCalled = false;
         private boolean wasAttributeReplacedCalled = false;

--- a/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
+++ b/mockrunner-servlet/src/test/java/com/mockrunner/test/web/MockHttpServletRequestTest.java
@@ -506,6 +506,13 @@ class MockHttpServletRequestTest
         assertFalse(request.isUserInRole("role3"));
     }
 
+    @Test
+    void testThatSetContentTypeAlsoSetsHeaderValue() {
+        String contentType = "application/octet-stream";
+        MockHttpServletRequest request = new MockHttpServletRequest().setContentType(contentType);
+        assertThat(request.getHeader(MockHttpServletRequest.CONTENT_TYPE)).isEqualTo(contentType);
+    }
+
     private class TestAttributeListener implements ServletRequestAttributeListener {
         private boolean wasAttributeAddedCalled = false;
         private boolean wasAttributeReplacedCalled = false;


### PR DESCRIPTION
@cemartins  This fixes https://github.com/mockrunner/mockrunner/issues/69

Going through the setters of MockHttpServletRequest I only found two headers it made sense to set from the setters:

1. Content-Type
2. Content-Length

I also did a suppression of complaints about using non-generics in mockrunner-servlet, since the javax.servlet-api uses non-generics.

Left warnings about deprecated code in place.