### PR TITLE
Replace OSSRH with Central Portal for releases and deploys to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,14 @@
 
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Staging Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>central</id>
+            <name>Central Portal</name>
+            <url>https://central.sonatype.com</url>
         </repository>
         <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Nexus Snaphots Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central-snapshots</id>
+            <name>Central Portal Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <site>
             <id>github-pages-site</id>
@@ -82,15 +82,15 @@
         </site>
     </distributionManagement>
 
-	<repositories>
-	    <repository>
-	        <id>sonatype-nexus-snapshots</id>
-	        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-	        <snapshots>
-	            <enabled>true</enabled>
-	        </snapshots>
-	    </repository>
-	</repositories>
+    <repositories>
+	<repository>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+	    <snapshots>
+	        <enabled>true</enabled>
+	    </snapshots>
+	</repository>
+    </repositories>
 
     <licenses>
         <license>
@@ -498,14 +498,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <nexusUrl>https://oss.sonatype.org</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
         </plugins>

--- a/settings.xml
+++ b/settings.xml
@@ -2,12 +2,12 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
     <servers>
         <server>
-            <id>ossrh</id>
+            <id>central</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
-            <id>sonatype-nexus-staging</id>
+            <id>central-staging</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
@@ -22,12 +22,11 @@
             </properties>
         </profile>
         <profile>
-            <id>sonatype-staging</id>
+            <id>central-portal</id>
             <repositories>
                 <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                    <layout>default</layout>
+                    <id>central</id>
+                    <url>https://central.sonatype.com</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -37,6 +36,6 @@
     </profiles>
     <activeProfiles>
         <activeProfile>gpg</activeProfile>
-        <activeProfile>sonatype-staging</activeProfile>
+        <activeProfile>central-portal</activeProfile>
     </activeProfiles>
 </settings>


### PR DESCRIPTION
@cemartins Not too sure about these changes. I have blindly replaced all references to to OSSRH and nexus with their central portal equivalents picked from my own projects.

But: reason I'm not sure: Release in my poms is structured completely different (something I got working in 2013 and have just pushed along, making necessary changes as the world has changed).

So this probably shouldn't be merged blindly? Take it as a suggestion.